### PR TITLE
feat: fix github ci/cd

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,6 @@ on:
     - master
     - develop
   pull_request:
-    branches:
-    - master
-    - develop
 
 jobs:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,10 +2,10 @@ name: Test
 
 on:
   push:
-  pull_request:
     branches:
-      - master
-      - develop
+    - master
+    - develop
+  pull_request:
 
 jobs:
   functional:


### PR DESCRIPTION
Configure CI to only run `master` and `develop` branches and PRs