### PR TITLE
 Add setName and setSymbols governance methods

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -110,7 +110,7 @@ abstract contract BaseStrategy {
 
     // Version of this contract
     function version() external pure returns (string memory) {
-        return "0.1.1";
+        return "0.1.2";
     }
 
     VaultAPI public vault;

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1,6 +1,6 @@
 #@version 0.2.7
 
-CONTRACT_VERSION: constant(String[28]) = "0.1.1"
+CONTRACT_VERSION: constant(String[28]) = "0.1.2"
 
 # TODO: Add ETH Configuration
 # TODO: Add Delegated Configuration

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -104,11 +104,11 @@ def __init__(
     # TODO: Non-detailed Configuration?
     self.token = ERC20(_token)
     if _nameOverride == "":
-        self.name = concat("yearn ", DetailedERC20(_token).name())
+        self.name = concat(DetailedERC20(_token).symbol(), " yVault")
     else:
         self.name = _nameOverride
     if _symbolOverride == "":
-        self.symbol = concat("y", DetailedERC20(_token).symbol())
+        self.symbol = concat("yv", DetailedERC20(_token).symbol())
     else:
         self.symbol = _symbolOverride
     self.decimals = DetailedERC20(_token).decimals()
@@ -125,6 +125,18 @@ def __init__(
 @external
 def version() -> String[28]:
     return CONTRACT_VERSION
+
+
+@external
+def setName(_name: String[42]):
+    assert msg.sender == self.governance
+    self.name = _name
+
+
+@external
+def setSymbol(_symbol: String[20]):
+    assert msg.sender == self.governance
+    self.symbol = _symbol
 
 
 # 2-phase commit for a change in governance

--- a/ethpm-config.yaml
+++ b/ethpm-config.yaml
@@ -1,5 +1,5 @@
 package_name: vault
-version: 0.1.1
+version: 0.1.2
 settings:
   deployment_networks:
     - mainnet

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -19,8 +19,8 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.rewards() == rewards
     assert vault.token() == token
     # UI Stuff
-    assert vault.name() == "yearn " + token.name()
-    assert vault.symbol() == "y" + token.symbol()
+    assert vault.name() == token.symbol() + " yVault"
+    assert vault.symbol() == "yv" + token.symbol()
     assert vault.decimals() == token.decimals()
     assert vault.version() == PACKAGE_VERSION
 
@@ -34,12 +34,10 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
 
 def test_vault_deployment_with_overrides(guardian, gov, rewards, token, Vault):
     # Deploy the Vault with name/symbol overrides
-    vault = guardian.deploy(
-        Vault, token, gov, rewards, "yearn Better Name", "yOVERRIDE"
-    )
+    vault = guardian.deploy(Vault, token, gov, rewards, "crvY yVault", "yvcrvY")
     # Assert that the overrides worked
-    assert vault.name() == "yearn Better Name"
-    assert vault.symbol() == "yOVERRIDE"
+    assert vault.name() == "crvY yVault"
+    assert vault.symbol() == "yvcrvY"
 
 
 @pytest.mark.parametrize(
@@ -92,3 +90,25 @@ def test_vault_setGovernance(guardian, gov, rewards, token, rando, Vault):
     # Only new governance can accept a change of governance
     with brownie.reverts():
         vault.acceptGovernance({"from": gov})
+
+
+def test_vault_setName(guardian, gov, rewards, token, rando, Vault):
+    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+
+    # No one can set name but governance
+    with brownie.reverts():
+        vault.setName("NewName yVault", {"from": rando})
+
+    vault.setName("NewName yVault", {"from": gov})
+    assert vault.name() == "NewName yVault"
+
+
+def test_vault_setSymbol(guardian, gov, rewards, token, rando, Vault):
+    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+
+    # No one can set symbol but governance
+    with brownie.reverts():
+        vault.setSymbol("yvNEW", {"from": rando})
+
+    vault.setSymbol("yvNEW", {"from": gov})
+    assert vault.symbol() == "yvNEW"


### PR DESCRIPTION
- Updated default symbol to `concat("yv", DetailedERC20(_token).symbol())`
- Updated default name to `self.name = concat(DetailedERC20(_token).symbol(), " yVault")`
- Adds setName and setSymbol methods for governance
- Updated Vault deployment tests
- Added new tests for setName and setSymbol