### PR TITLE
Updates to Strategy API

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -320,7 +320,7 @@ abstract contract BaseStrategy {
     // Override this to add all tokens this contract manages on a *persistant* basis
     // (e.g. not just for swapping back to want ephemerally)
     // NOTE: Must inclide `want` token
-    function protectedTokens() internal view returns (address[] memory) {
+    function protectedTokens() internal virtual view returns (address[] memory) {
         address[] memory protected = new address[](1);
         protected[0] = address(want);
         return protected;

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -16,6 +16,8 @@ struct StrategyParams {
 }
 
 interface VaultAPI {
+    function apiVersion() external view returns (string memory);
+
     function token() external view returns (address);
 
     function strategies(address _strategy) external view returns (StrategyParams memory);
@@ -84,6 +86,10 @@ interface VaultAPI {
  * This interface is here for the keeper bot to use
  */
 interface StrategyAPI {
+    function apiVersion() external pure returns (string memory);
+
+    function name() external pure returns (string memory);
+
     function vault() external view returns (address);
 
     function keeper() external view returns (address);
@@ -108,8 +114,8 @@ interface StrategyAPI {
 abstract contract BaseStrategy {
     using SafeMath for uint256;
 
-    // Version of this contract
-    function version() external pure returns (string memory) {
+    // Version of this contract's StrategyAPI (must match Vault)
+    function apiVersion() public pure returns (string memory) {
         return "0.1.2";
     }
 

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -119,6 +119,11 @@ abstract contract BaseStrategy {
         return "0.1.2";
     }
 
+    // Name of this contract's Strategy (Must override!)
+    // NOTE: You can use this field to manage the "version" of this strategy
+    //       e.g. `StrategySomethingOrOtherV1`. It's up to you!
+    function name() external virtual pure returns (string memory);
+
     VaultAPI public vault;
     address public strategist;
     address public keeper;

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1,6 +1,6 @@
 #@version 0.2.7
 
-CONTRACT_VERSION: constant(String[28]) = "0.1.2"
+API_VERSION: constant(String[28]) = "0.1.2"
 
 # TODO: Add ETH Configuration
 # TODO: Add Delegated Configuration
@@ -123,8 +123,8 @@ def __init__(
 
 @pure
 @external
-def version() -> String[28]:
-    return CONTRACT_VERSION
+def apiVersion() -> String[28]:
+    return API_VERSION
 
 
 @external

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -12,6 +12,10 @@ import {BaseStrategy, StrategyParams} from "../BaseStrategy.sol";
 contract TestStrategy is BaseStrategy {
     constructor(address _vault) public BaseStrategy(_vault) {}
 
+    function name() external override pure returns (string memory) {
+        return "TestStrategy";
+    }
+
     // When exiting the position, wait this many times to give everything back
     uint256 countdownTimer = 3;
 

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -14,7 +14,7 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert strategy.strategist() == strategist
     assert strategy.keeper() == strategist
     assert strategy.want() == vault.token()
-    assert vault.version() == PACKAGE_VERSION
+    assert strategy.apiVersion() == PACKAGE_VERSION
 
     assert strategy.reserve() == 0
     assert not strategy.emergencyExit()

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -15,6 +15,7 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert strategy.keeper() == strategist
     assert strategy.want() == vault.token()
     assert strategy.apiVersion() == PACKAGE_VERSION
+    assert strategy.name() == "TestStrategy"
 
     assert strategy.reserve() == 0
     assert not strategy.emergencyExit()

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -22,7 +22,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.name() == token.symbol() + " yVault"
     assert vault.symbol() == "yv" + token.symbol()
     assert vault.decimals() == token.decimals()
-    assert vault.version() == PACKAGE_VERSION
+    assert vault.apiVersion() == PACKAGE_VERSION
 
     assert vault.debtLimit() == 0
     assert vault.depositLimit() == 2 ** 256 - 1


### PR DESCRIPTION
- [x] Changed `Vault.version()` and `Strategy.version()` to `*.apiVersion()` to clarify intent of this function (mostly for Strategy usage)
- [x] Added `Strategy.name()` required override function so that users give their strategies a custom name
- [x] Fixed `Strategy.protectedTokens()` optional override function so that users can define their own list (or use the default)