### PR TITLE
refactor: remove additional check on approvals

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -231,13 +231,10 @@ def approve(_spender : address, _value : uint256) -> bool:
     @dev Approve the passed address to spend the specified amount of tokens on behalf of
          msg.sender. Beware that changing an allowance with this method brings the risk
          that someone may use both the old and the new allowance by unfortunate transaction
-         ordering. One possible solution to mitigate this race condition is to first reduce
-         the spender's allowance to 0 and set the desired value afterwards:
-         https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+         ordering. See https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
     @param _spender The address which will spend the funds.
     @param _value The amount of tokens to be spent.
     """
-    assert _value == 0 or self.allowance[msg.sender][_spender] == 0
     self.allowance[msg.sender][_spender] = _value
     log Approval(msg.sender, _spender, _value)
     return True

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -187,12 +187,6 @@ def test_transferFrom(accounts, token, vault, fn_isolation):
     with brownie.reverts():
         vault.transferFrom(a, b, vault.balanceOf(a) // 2, {"from": c})
 
-    # Show that approval ordering protection works
-    vault.approve(c, vault.balanceOf(a), {"from": a})  # oopsies, wrong value
-    with brownie.reverts():
-        vault.approve(c, vault.balanceOf(a) // 2, {"from": a})
-    vault.approve(c, 0, {"from": a})
-
     vault.approve(c, vault.balanceOf(a) // 2, {"from": a})
     assert vault.allowance(a, c) == vault.balanceOf(a) // 2
 


### PR DESCRIPTION
Removes the overly onerous approval check as a mitigation for a minor vulnerability in ERC20 implementation.