### PR TITLE
Refactor Strategy API

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -317,16 +317,14 @@ abstract contract BaseStrategy {
         outstanding = vault.report(want.balanceOf(address(this)).sub(reserve));
     }
 
-    // Override this to add all tokens this contract manages on a *persistant* basis
-    // (e.g. not just for swapping back to want ephemerally)
-    // NOTE: Must inclide `want` token
-    function protectedTokens() internal virtual view returns (address[] memory) {
-        address[] memory protected = new address[](1);
-        protected[0] = address(want);
-        return protected;
-    }
+    // Override this to add all tokens/tokenized positions this contract manages
+    // on a *persistant* basis (e.g. not just for swapping back to want ephemerally)
+    // NOTE: Do *not* include `want`, already included in `sweep` below
+    function protectedTokens() internal virtual view returns (address[] memory);
 
     function sweep(address _token) external {
+        require(_token != address(want), "!want");
+
         address[] memory _protectedTokens = protectedTokens();
         for (uint256 i; i < _protectedTokens.length; i++) require(_token != _protectedTokens[i], "!protected");
 

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -10,7 +10,7 @@ struct StrategyParams {
     uint256 activation;
     uint256 debtLimit;
     uint256 rateLimit;
-    uint256 lastSync;
+    uint256 lastReport;
     uint256 totalDebt;
     uint256 totalReturns;
 }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -15,7 +15,7 @@ struct StrategyParams {
     uint256 totalReturns;
 }
 
-interface VaultAPI {
+interface VaultAPI is IERC20 {
     function apiVersion() external view returns (string memory);
 
     function token() external view returns (address);
@@ -240,6 +240,15 @@ abstract contract BaseStrategy {
      * instead of `prepareReturn()`
      */
     function exitPosition() internal virtual;
+
+    /*
+     * Vault calls this function after shares are created during `Vault.report()`.
+     * You can customize this function to any share distribution mechanism you want.
+     */
+    function distributeRewards(uint256 _shares) external virtual {
+        // Send 100% of newly-minted shares to the strategist.
+        vault.transfer(strategist, _shares);
+    }
 
     /*
      * Provide a signal to the keeper that `tend()` should be called. The keeper will provide

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -372,6 +372,16 @@ abstract contract BaseStrategy {
     // Override this to add all tokens/tokenized positions this contract manages
     // on a *persistant* basis (e.g. not just for swapping back to want ephemerally)
     // NOTE: Do *not* include `want`, already included in `sweep` below
+    //
+    // Example:
+    //
+    //    function protectedTokens() internal override view returns (address[] memory) {
+    //      address[] memory protected = new address[](3);
+    //      protected[0] = tokenA;
+    //      protected[1] = tokenB;
+    //      protected[2] = tokenC;
+    //      return protected;
+    //    }
     function protectedTokens() internal virtual view returns (address[] memory);
 
     function sweep(address _token) external {

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -362,7 +362,7 @@ abstract contract BaseStrategy {
     }
 
     function setEmergencyExit() external {
-        require(msg.sender == strategist || msg.sender == governance());
+        require(msg.sender == strategist || msg.sender == governance(), "!authorized");
         emergencyExit = true;
         exitPosition();
         vault.revokeStrategy();

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -385,6 +385,7 @@ abstract contract BaseStrategy {
     function protectedTokens() internal virtual view returns (address[] memory);
 
     function sweep(address _token) external {
+        require(msg.sender == governance(), "!authorized");
         require(_token != address(want), "!want");
 
         address[] memory _protectedTokens = protectedTokens();

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -131,7 +131,7 @@ abstract contract BaseStrategy {
     IERC20 public want;
 
     // So indexers can keep track of this
-    event Harvested(uint256 wantEarned, uint256 lifetimeEarned);
+    event Harvested(uint256 profit);
 
     // Adjust this to keep some of the position in reserve in the strategy,
     // to accomodate larger variations needed to sustain the strategy's core positon(s)
@@ -274,7 +274,7 @@ abstract contract BaseStrategy {
 
         adjustPosition(); // Check if free returns are left, and re-invest them
 
-        emit Harvested(wantEarned, vault.strategies(address(this)).totalReturns);
+        emit Harvested(profit);
     }
 
     /*

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -116,7 +116,7 @@ abstract contract BaseStrategy {
 
     // Version of this contract's StrategyAPI (must match Vault)
     function apiVersion() public pure returns (string memory) {
-        return "0.1.2";
+        return "0.1.3";
     }
 
     // Name of this contract's Strategy (Must override!)

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -289,7 +289,7 @@ abstract contract BaseStrategy {
      *
      * NOTE: this call and `tendTrigger` should never return `true` at the same time.
      */
-    function harvestTrigger(uint256 callCost) public view returns (bool) {
+    function harvestTrigger(uint256 callCost) public virtual view returns (bool) {
         StrategyParams memory params = vault.strategies(address(this));
 
         // Should not trigger if strategy is not activated

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -175,13 +175,6 @@ abstract contract BaseStrategy {
     }
 
     /*
-     * Provide an accurate expected value for the return this strategy
-     * would provide to the Vault the next time `report()` is called
-     * (since the last time it was called)
-     */
-    function expectedReturn() public virtual view returns (uint256);
-
-    /*
      * Provide an accurate estimate for the total amount of assets (principle + return)
      * that this strategy is currently managing, denominated in terms of `want` tokens.
      * This total should be "realizable" e.g. the total value that could *actually* be

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -133,9 +133,9 @@ abstract contract BaseStrategy {
     // So indexers can keep track of this
     event Harvested(uint256 profit);
 
-    // The maximum number of blocks between harvest calls
+    // The minimum number of blocks between harvest calls
     // NOTE: Override this value with your own, or set dynamically below
-    uint256 public maxReportDelay = 6300; // ~ once a day
+    uint256 public minReportDelay = 6300; // ~ once a day
 
     // The minimum multiple that `callCost` must be above the credit/profit to be "justifiable"
     // NOTE: Override this value with your own, or set dynamically below
@@ -173,9 +173,9 @@ abstract contract BaseStrategy {
         keeper = _keeper;
     }
 
-    function setMaxReportDelay(uint256 _delay) external {
+    function setMinReportDelay(uint256 _delay) external {
         require(msg.sender == strategist || msg.sender == governance(), "!authorized");
-        maxReportDelay = _delay;
+        minReportDelay = _delay;
     }
 
     function setProfitFactor(uint256 _profitFactor) external {
@@ -287,7 +287,7 @@ abstract contract BaseStrategy {
         if (params.activation == 0) return false;
 
         // Should trigger if hadn't been called in a while
-        if (block.number.sub(params.lastReport) >= maxReportDelay) return true;
+        if (block.number.sub(params.lastReport) >= minReportDelay) return true;
 
         // If some amount is owed, pay it back
         // NOTE: Since debt is adjusted in step-wise fashion, it is appropiate to always trigger here,

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -133,6 +133,10 @@ abstract contract BaseStrategy {
     // So indexers can keep track of this
     event Harvested(uint256 profit);
 
+    // The minimum multiple that `callCost` must be above the credit/profit to be "justifiable"
+    // NOTE: Override this value with your own, or set dynamically below
+    uint256 public profitFactor = 100;
+
     // Adjust this using `setReserve(...)` to keep some of the position in reserve in the strategy,
     // to accomodate larger variations needed to sustain the strategy's core positon(s)
     uint256 private reserve = 0;
@@ -163,6 +167,11 @@ abstract contract BaseStrategy {
     function setKeeper(address _keeper) external {
         require(msg.sender == strategist || msg.sender == governance(), "!authorized");
         keeper = _keeper;
+    }
+
+    function setProfitFactor(uint256 _profitFactor) external {
+        require(msg.sender == strategist || msg.sender == governance(), "!authorized");
+        profitFactor = _profitFactor;
     }
 
     /*
@@ -283,7 +292,7 @@ abstract contract BaseStrategy {
 
         // Otherwise, only trigger if it "makes sense" economically (gas cost is <N% of value moved)
         uint256 credit = vault.creditAvailable();
-        return (100 * callCost < credit.add(profit));
+        return (profitFactor * callCost < credit.add(profit));
     }
 
     function harvest() external {

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -306,7 +306,8 @@ abstract contract BaseStrategy {
 
         // Check for profits and losses
         uint256 total = estimatedTotalAssets();
-        if (total < params.totalDebt) return true; // We have a loss to report!
+        // Trigger if we have a loss to report
+        if (total < params.totalDebt) return params.totalDebt.sub(total).mul(profitFactor) > callCost;
 
         uint256 profit = 0;
         if (total > params.totalDebt) profit = total.sub(params.totalDebt); // We've earned a profit!

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -14,7 +14,7 @@ interface DetailedERC20:
     def decimals() -> uint256: view
 
 interface Strategy:
-    def strategist() -> address: view
+    def distributeRewards(_shares: uint256): nonpayable
     def estimatedTotalAssets() -> uint256: view
     def withdraw(_amount: uint256): nonpayable
     def migrate(_newStrategy: address): nonpayable
@@ -754,7 +754,8 @@ def report(_return: uint256) -> uint256:
     # Send the rewards out as new shares in this Vault
     if strategist_fee > 0:
         strategist_reward: uint256 = (strategist_fee * reward) / total_fee
-        self._transfer(self, Strategy(msg.sender).strategist(), strategist_reward)
+        self._transfer(self, msg.sender, strategist_reward)
+        Strategy(msg.sender).distributeRewards(strategist_reward)
     # NOTE: Governance earns any dust leftover from flooring math above
     self._transfer(self, self.rewards, self.balanceOf[self])
 

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -844,6 +844,7 @@ def erc20_safe_transfer(_token: address, _to: address, _value: uint256):
 
 @external
 def sweep(_token: address):
+    assert msg.sender == self.governance
     # Can't be used to steal what this Vault is protecting
     assert _token != self.token.address
     self.erc20_safe_transfer(_token, self.governance, ERC20(_token).balanceOf(self))

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1,6 +1,6 @@
 #@version 0.2.7
 
-API_VERSION: constant(String[28]) = "0.1.2"
+API_VERSION: constant(String[28]) = "0.1.3"
 
 # TODO: Add ETH Configuration
 # TODO: Add Delegated Configuration

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -25,41 +25,50 @@ contract TestStrategy is BaseStrategy {
     }
 
     function estimatedTotalAssets() public override view returns (uint256) {
+        // For mock, this is just everything we have
         return want.balanceOf(address(this));
     }
 
-    function prepareReturn() internal override {
+    function prepareReturn(uint256 _debtOutstanding) internal override returns (uint256 _profit) {
         // During testing, send this contract some tokens to simulate "Rewards"
+        uint256 reserve = getReserve();
+        uint256 total = want.balanceOf(address(this));
+        if (total > reserve.add(_debtOutstanding)) _profit = total.sub(reserve).sub(_debtOutstanding);
     }
 
-    function adjustPosition() internal override {
+    function adjustPosition(uint256 _debtOutstanding) internal override {
         // Whatever we have "free", consider it "invested" now
-        if (outstanding <= want.balanceOf(address(this))) {
-            reserve = want.balanceOf(address(this)).sub(outstanding);
+        uint256 total = want.balanceOf(address(this));
+        if (total > _debtOutstanding) {
+            setReserve(total.sub(_debtOutstanding));
         } else {
-            reserve = 0;
+            setReserve(0);
         }
     }
 
-    function liquidatePosition(uint256 _amount) internal override {
-        if (_amount > reserve) {
-            reserve = 0;
+    function liquidatePosition(uint256 _amountNeeded) internal override returns (uint256 _amountFreed) {
+        uint256 reserve = getReserve();
+        if (_amountNeeded >= reserve) {
+            // Give back the entire reserves
+            _amountFreed = reserve;
         } else {
-            reserve = reserve.sub(_amount);
+            // Give back a portion of the reserves
+            _amountFreed = _amountNeeded;
         }
+        setReserve(reserve.sub(_amountFreed));
     }
 
     function exitPosition() internal override {
-        // Dump 25% each time this is called, the first 3 times
-        reserve = want.balanceOf(address(this)).mul(countdownTimer).div(4);
-        countdownTimer.sub(1); // NOTE: This should never be called after it hits 0
+        // Dump 1/N of original position each time this is called
+        setReserve(want.balanceOf(address(this)).mul(countdownTimer.sub(1)).div(countdownTimer));
+        countdownTimer = countdownTimer.sub(1); // NOTE: This should never be called after it hits 0
     }
 
     function prepareMigration(address _newStrategy) internal override {
-        want.transfer(_newStrategy, want.balanceOf(address(this)));
+        // Nothing needed here because no additional tokens/tokenized positions for mock
     }
 
     function protectedTokens() internal override view returns (address[] memory) {
-        return new address[](0);
+        return new address[](0); // No additional tokens/tokenized positions for mock
     }
 }

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -49,10 +49,6 @@ contract TestStrategy is BaseStrategy {
         return (100 * gasCost < credit.add(profit));
     }
 
-    function expectedReturn() public override view returns (uint256) {
-        return vault.expectedReturn();
-    }
-
     function estimatedTotalAssets() public override view returns (uint256) {
         return want.balanceOf(address(this));
     }

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -87,4 +87,8 @@ contract TestStrategy is BaseStrategy {
     function prepareMigration(address _newStrategy) internal override {
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }
+
+    function protectedTokens() internal override view returns (address[] memory) {
+        return new address[](0);
+    }
 }

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -24,31 +24,6 @@ contract TestStrategy is BaseStrategy {
         want.transfer(msg.sender, amount);
     }
 
-    function tendTrigger(uint256 gasCost) public override view returns (bool) {
-        // In our example, we don't ever need tend, but if there are positions
-        // that need active maintainence, this is how you would signal for that
-        // NOTE: Must be mutually exclusive of `harvestTrigger`
-        //       (both can be false, but both should not be true)
-        return false;
-    }
-
-    function harvestTrigger(uint256 gasCost) public override view returns (bool) {
-        StrategyParams memory params = vault.strategies(address(this));
-
-        // Should not trigger if strategy is not activated
-        if (params.activation == 0) return false;
-
-        // If some amount is owed, pay it back
-        if (outstanding > 0 || vault.debtOutstanding() > 0) return true;
-
-        // Only trigger if it "makes sense" economically (<1% of value moved)
-        uint256 credit = vault.creditAvailable();
-        uint256 profit = 0;
-        if (want.balanceOf(address(this)) > reserve) profit = want.balanceOf(address(this)).sub(reserve);
-        // NOTE: Assume a 1:1 price here, for testing purposes
-        return (100 * gasCost < credit.add(profit));
-    }
-
     function estimatedTotalAssets() public override view returns (uint256) {
         return want.balanceOf(address(this));
     }

--- a/ethpm-config.yaml
+++ b/ethpm-config.yaml
@@ -1,5 +1,5 @@
 package_name: vault
-version: 0.1.2
+version: 0.1.3
 settings:
   deployment_networks:
     - mainnet

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -17,7 +17,6 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert strategy.apiVersion() == PACKAGE_VERSION
     assert strategy.name() == "TestStrategy"
 
-    assert strategy.reserve() == 0
     assert not strategy.emergencyExit()
 
     # Should not trigger until it is approved

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import yaml
 
+import pytest
 import brownie
 
 PACKAGE_VERSION = yaml.safe_load(
@@ -24,36 +25,6 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert not strategy.tendTrigger(0)
 
 
-def test_vault_setStrategist(strategy, gov, strategist, rando):
-    # Only governance or strategist can set this param
-    with brownie.reverts():
-        strategy.setStrategist(rando, {"from": rando})
-    assert strategy.strategist() != rando
-
-    strategy.setStrategist(rando, {"from": gov})
-    assert strategy.strategist() == rando
-
-    strategy.setStrategist(strategist, {"from": rando})
-    assert strategy.strategist() == strategist
-
-
-def test_vault_setKeeper(strategy, gov, strategist, rando):
-    # Only governance or strategist can set this param
-    with brownie.reverts():
-        strategy.setKeeper(rando, {"from": rando})
-    assert strategy.keeper() != rando
-
-    strategy.setKeeper(rando, {"from": gov})
-    assert strategy.keeper() == rando
-
-    # Only governance or strategist can set this param
-    with brownie.reverts():
-        strategy.setKeeper(rando, {"from": rando})
-
-    strategy.setKeeper(strategist, {"from": strategist})
-    assert strategy.keeper() == strategist
-
-
 def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
     # Only governance or strategist can set this param
     with brownie.reverts():
@@ -68,3 +39,33 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
 
     strategy.setEmergencyExit({"from": strategist})
     assert strategy.emergencyExit()
+
+
+@pytest.mark.parametrize(
+    "getter,setter,val",
+    [
+        ("strategist", "setStrategist", None),
+        ("keeper", "setKeeper", None),
+    ],
+)
+def test_strategy_setParams(gov, strategist, strategy, rando, getter, setter, val):
+    if not val:
+        # Can't access fixtures, so use None to mean any random address
+        val = rando
+
+    prev_val = getattr(strategy, getter)()
+
+    # Only governance or strategist can set this param
+    with brownie.reverts():
+        getattr(strategy, setter)(val, {"from": rando})
+
+    getattr(strategy, setter)(val, {"from": strategist})
+    assert getattr(strategy, getter)() == val
+
+    if getter == "strategist":
+        # Strategist can't change themselves once they update
+        with brownie.reverts():
+            strategy.setStrategist(strategist, {"from": strategist})
+
+    getattr(strategy, setter)(prev_val, {"from": gov})
+    assert getattr(strategy, getter)() == prev_val

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -20,7 +20,6 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert strategy.reserve() == 0
     assert not strategy.emergencyExit()
 
-    assert strategy.expectedReturn() == 0
     # Should not trigger until it is approved
     assert not strategy.harvestTrigger(0)
     assert not strategy.tendTrigger(0)

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -46,6 +46,8 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
     [
         ("strategist", "setStrategist", None),
         ("keeper", "setKeeper", None),
+        ("maxReportDelay", "setMaxReportDelay", 1000),
+        ("profitFactor", "setProfitFactor", 1000),
     ],
 )
 def test_strategy_setParams(gov, strategist, strategy, rando, getter, setter, val):

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -46,7 +46,7 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
     [
         ("strategist", "setStrategist", None),
         ("keeper", "setKeeper", None),
-        ("maxReportDelay", "setMaxReportDelay", 1000),
+        ("minReportDelay", "setMinReportDelay", 1000),
         ("profitFactor", "setProfitFactor", 1000),
     ],
 )

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -67,12 +67,16 @@ def test_sweep(gov, strategy, rando, token, other_token):
     with brownie.reverts():
         strategy.sweep(token, {"from": gov})
 
-    # But any other random token works (and any random person can do this)
+    # But any other random token works
     assert other_token.address != strategy.want()
     assert other_token.balanceOf(strategy) > 0
     assert other_token.balanceOf(gov) == 0
+    # Not any random person can do this
+    with brownie.reverts():
+        strategy.sweep(other_token, {"from": rando})
+
     before = other_token.balanceOf(strategy)
-    strategy.sweep(other_token, {"from": rando})
+    strategy.sweep(other_token, {"from": gov})
     assert other_token.balanceOf(strategy) == 0
     assert other_token.balanceOf(gov) == before
     assert other_token.balanceOf(rando) == 0

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -30,7 +30,6 @@ def test_emergency_shutdown(token, gov, vault, strategy, keeper, chain):
     # All the debt is out of the system now
     assert vault.totalDebt() == 0
     assert vault.strategies(strategy)[5] == 0
-    assert strategy.outstanding() == 0
 
     # Do it once more, for good luck (and also coverage)
     token.transfer(strategy, token.balanceOf(gov), {"from": gov})
@@ -77,7 +76,6 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain):
     # All the debt left is out of the system now
     assert vault.totalDebt() == stolen_funds
     assert vault.strategies(strategy)[5] == stolen_funds
-    assert strategy.outstanding() == stolen_funds
 
     # Vault returned something overall though
     strategyReturn = vault.strategies(strategy)[6]

--- a/tests/functional/strategy/test_startup.py
+++ b/tests/functional/strategy/test_startup.py
@@ -5,7 +5,6 @@ def test_startup(token, gov, vault, strategy, keeper, chain):
     # Never reported yet
     # NOTE: done for coverage
     vault.expectedReturn(strategy) == 0
-    assert strategy.outstanding() == strategy.reserve() == 0
     assert vault.balanceSheetOfStrategy(strategy) == 0
     assert not strategy.harvestTrigger(0)
     chain.mine(50)
@@ -22,11 +21,9 @@ def test_startup(token, gov, vault, strategy, keeper, chain):
     # Check balance is increasing
     assert token.balanceOf(strategy) > 0
     last_balance = token.balanceOf(strategy)
-    assert strategy.reserve() == last_balance
 
     # Check accounting is maintained everywhere
     assert vault.totalDebt() == vault.strategies(strategy)[5]  # totalDebt
-    assert strategy.outstanding() == 0
     assert vault.balanceSheetOfStrategy(strategy) == vault.totalDebt()
     assert (
         vault.totalBalanceSheet(withdrawal_queue)
@@ -44,11 +41,9 @@ def test_startup(token, gov, vault, strategy, keeper, chain):
     # Check balance is increasing
     assert token.balanceOf(strategy) > last_balance
     last_balance = token.balanceOf(strategy)
-    assert strategy.reserve() == last_balance
 
     # Check accounting is maintained everywhere
     assert vault.totalDebt() == vault.strategies(strategy)[5]  # totalDebt
-    assert strategy.outstanding() == 0
     assert vault.balanceSheetOfStrategy(strategy) == vault.totalDebt()
     assert (
         vault.totalBalanceSheet(withdrawal_queue)
@@ -72,11 +67,9 @@ def test_startup(token, gov, vault, strategy, keeper, chain):
         # Check balance is increasing
         assert token.balanceOf(strategy) > last_balance
         last_balance = token.balanceOf(strategy)
-        assert strategy.reserve() == last_balance
 
         # Check accounting is maintained everywhere
         assert vault.totalDebt() == vault.strategies(strategy)[5]  # totalDebt
-        assert strategy.outstanding() == 0
         assert vault.balanceSheetOfStrategy(strategy) == vault.totalDebt()
         assert (
             vault.totalBalanceSheet(withdrawal_queue)

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -32,7 +32,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.totalAssets() == 0
 
 
-def test_vault_deployment_with_overrides(guardian, gov, rewards, token, Vault):
+def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):
     # Deploy the Vault with name/symbol overrides
     vault = guardian.deploy(Vault, token, gov, rewards, "crvY yVault", "yvcrvY")
     # Assert that the overrides worked
@@ -43,6 +43,8 @@ def test_vault_deployment_with_overrides(guardian, gov, rewards, token, Vault):
 @pytest.mark.parametrize(
     "getter,setter,val",
     [
+        ("name", "setName", "NewName yVault"),
+        ("symbol", "setSymbol", "yvNEW"),
         ("emergencyShutdown", "setEmergencyShutdown", True),
         ("guardian", "setGuardian", None),
         ("rewards", "setRewards", None),
@@ -90,25 +92,3 @@ def test_vault_setGovernance(guardian, gov, rewards, token, rando, Vault):
     # Only new governance can accept a change of governance
     with brownie.reverts():
         vault.acceptGovernance({"from": gov})
-
-
-def test_vault_setName(guardian, gov, rewards, token, rando, Vault):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
-
-    # No one can set name but governance
-    with brownie.reverts():
-        vault.setName("NewName yVault", {"from": rando})
-
-    vault.setName("NewName yVault", {"from": gov})
-    assert vault.name() == "NewName yVault"
-
-
-def test_vault_setSymbol(guardian, gov, rewards, token, rando, Vault):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
-
-    # No one can set symbol but governance
-    with brownie.reverts():
-        vault.setSymbol("yvNEW", {"from": rando})
-
-    vault.setSymbol("yvNEW", {"from": gov})
-    assert vault.symbol() == "yvNEW"

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -51,17 +51,12 @@ def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):
         ("performanceFee", "setPerformanceFee", 1000),
         ("managementFee", "setManagementFee", 1000),
         ("depositLimit", "setDepositLimit", 1000),
-        ("guardian", "setGuardian", None),
     ],
 )
-def test_vault_setParams(
-    guardian, gov, rewards, token, rando, getter, setter, val, Vault
-):
+def test_vault_setParams(gov, vault, rando, getter, setter, val):
     if not val:
         # Can't access fixtures, so use None to mean any random address
         val = rando
-
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
 
     # Only governance can set this param
     with brownie.reverts():
@@ -71,8 +66,7 @@ def test_vault_setParams(
     assert getattr(vault, getter)() == val
 
 
-def test_vault_setGovernance(guardian, gov, rewards, token, rando, Vault):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+def test_vault_setGovernance(gov, vault, rando):
     newGov = rando
     # No one can set governance but governance
     with brownie.reverts():

--- a/tests/functional/vault/test_misc.py
+++ b/tests/functional/vault/test_misc.py
@@ -17,12 +17,16 @@ def test_sweep(gov, vault, rando, token, other_token):
     with brownie.reverts():
         vault.sweep(token, {"from": gov})
 
-    # But any other random token works (and any random person can do this)
+    # But any other random token works
     assert other_token.address != vault.token()
     assert other_token.balanceOf(vault) > 0
     assert other_token.balanceOf(gov) == 0
+    # Not any random person can do this
+    with brownie.reverts():
+        vault.sweep(other_token, {"from": rando})
+
     before = other_token.balanceOf(vault)
-    vault.sweep(other_token, {"from": rando})
+    vault.sweep(other_token, {"from": gov})
     assert other_token.balanceOf(vault) == 0
     assert other_token.balanceOf(gov) == before
     assert other_token.balanceOf(rando) == 0


### PR DESCRIPTION
A series of fixes to simplify how strategist use `BaseStrategy`
- [x] Simplify protected tokens interface
- [x] Remove `expectedReturn`
- [x] Fix `StrategyParams.lastReport` in `BaseStrategy`
- [x] Remove `lifetimeEarned` from `BaseStrategy.Harvest` event (can query this using `Vault.StrategyReported` instead)
- [x] Move `*Trigger` functions to `BaseStrategy` template (overrideable)
- [x] Reconfigure `BaseStrategy` API touchpoints to not have to read/write storage values directly
- [x] Add a method to force `harvest` to trigger based on time

Bumped API Version to 0.1.3