### PR TITLE
Add increase/decrease allowance functions

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -240,6 +240,36 @@ def approve(_spender : address, _value : uint256) -> bool:
     return True
 
 
+@external
+def increaseAllowance(_spender : address, _value : uint256) -> bool:
+    """
+    @dev Increase the allowance of the passed address to spend the total amount of tokens
+         on behalf of msg.sender. This method mitigates the risk that someone may use both
+         the old and the new allowance by unfortunate transaction ordering.
+         See https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will spend the funds.
+    @param _value The amount of tokens to increase the allowance by.
+    """
+    self.allowance[msg.sender][_spender] += _value
+    log Approval(msg.sender, _spender, self.allowance[msg.sender][_spender])
+    return True
+
+
+@external
+def decreaseAllowance(_spender : address, _value : uint256) -> bool:
+    """
+    @dev Decrease the allowance of the passed address to spend the total amount of tokens
+         on behalf of msg.sender. This method mitigates the risk that someone may use both
+         the old and the new allowance by unfortunate transaction ordering.
+         See https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+    @param _spender The address which will spend the funds.
+    @param _value The amount of tokens to decrease the allowance by.
+    """
+    self.allowance[msg.sender][_spender] -= _value
+    log Approval(msg.sender, _spender, self.allowance[msg.sender][_spender])
+    return True
+
+
 @view
 @internal
 def _totalAssets() -> uint256:

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -190,6 +190,12 @@ def test_transferFrom(accounts, token, vault, fn_isolation):
     vault.approve(c, vault.balanceOf(a) // 2, {"from": a})
     assert vault.allowance(a, c) == vault.balanceOf(a) // 2
 
+    vault.increaseAllowance(c, vault.balanceOf(a) // 2, {"from": a})
+    assert vault.allowance(a, c) == vault.balanceOf(a)
+
+    vault.decreaseAllowance(c, vault.balanceOf(a) // 2, {"from": a})
+    assert vault.allowance(a, c) == vault.balanceOf(a) // 2
+
     # Can't send more than what is approved
     with brownie.reverts():
         vault.transferFrom(a, b, vault.balanceOf(a), {"from": c})


### PR DESCRIPTION
Since we removed the mitigation on approvals in #44, it makes sense to add the recommended mitigation which is 2 functions that atomically change the allowance