### PR TITLE
Vault Registry (take 2)

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -17,6 +17,10 @@ struct StrategyParams {
 }
 
 interface VaultAPI is IERC20 {
+    function name() external view returns (string memory);
+
+    function symbol() external view returns (string memory);
+
     function apiVersion() external view returns (string memory);
 
     function token() external view returns (address);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import "@openzeppelinV3/contracts/math/SafeMath.sol";
+import "@openzeppelinV3/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelinV3/contracts/utils/Address.sol";
+import "@openzeppelinV3/contracts/utils/EnumerableSet.sol";
+
+import {VaultAPI} from "./BaseStrategy.sol";
+
+struct VaultData {
+    address vaultAddress;
+    string vaultName;
+    string vaultSymbol;
+    string vaultApiVersion;
+    address tokenAddress;
+    string tokenName;
+    string tokenSymbol;
+    uint256 tokenDecimals; // NOTE: Vault.decimals() == Token.decimals()
+}
+
+contract Registry {
+    using Address for address;
+    using SafeMath for uint256;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    address public governance;
+    address pendingGovernance;
+
+    EnumerableSet.AddressSet private vaults;
+
+    constructor(address _governance) public {
+        require(_governance != address(0), "Missing Governance");
+        governance = _governance;
+    }
+
+    // Governance setters
+    function setGovernance(address _governance) external onlyGovernance {
+        pendingGovernance = _governance;
+    }
+
+    function acceptGovernance() external {
+        require(msg.sender == pendingGovernance, "!pendingGovernance");
+        governance = msg.sender;
+    }
+
+    modifier onlyGovernance {
+        require(msg.sender == governance, "!governance");
+        _;
+    }
+
+    // Vault set actions
+    function addVault(address _vault) public onlyGovernance {
+        require(_vault.isContract(), "Vault is not a contract");
+        // Checks if vault is already on the array
+        require(!vaults.contains(_vault), "Vault already exists");
+        // Adds unique _vault to vaults array
+        vaults.add(_vault);
+    }
+
+    function removeVault(address _vault) public onlyGovernance {
+        // Checks if vault is already on the array
+        require(vaults.contains(_vault), "Vault not in set");
+        // Remove _vault to vaults array
+        vaults.remove(_vault);
+    }
+
+    function getVaultData(address _vault) internal view returns (VaultData memory) {
+        address token = VaultAPI(_vault).token();
+        return
+            VaultData({
+                vaultAddress: _vault,
+                vaultName: VaultAPI(_vault).name(),
+                vaultSymbol: VaultAPI(_vault).symbol(),
+                vaultApiVersion: VaultAPI(_vault).apiVersion(),
+                tokenAddress: token,
+                tokenName: ERC20(token).name(),
+                tokenSymbol: ERC20(token).symbol(),
+                tokenDecimals: ERC20(token).decimals()
+            });
+    }
+
+    // Vaults getters
+    function getVault(uint256 _index) external view returns (VaultData memory) {
+        return getVaultData(vaults.at(_index));
+    }
+
+    function getVault(address _vault) external view returns (VaultData memory) {
+        return getVaultData(_vault);
+    }
+
+    function getVaultsLength() external view returns (uint256) {
+        return vaults.length();
+    }
+
+    function getVaults() external view returns (VaultData[] memory) {
+        VaultData[] memory vaultsArray = new VaultData[](vaults.length());
+        for (uint256 i = 0; i < vaults.length(); i++) {
+            vaultsArray[i] = getVaultData(vaults.at(i));
+        }
+        return vaultsArray;
+    }
+}


### PR DESCRIPTION
fixes: #45

Vault Registry, used for managing the list of "official" Yearn Vaults for the ecosystem.

Features:
- [x] Governance controlled (2-phase upgrade)
- [x] Getter for data of specific Vault
- [x] Getter for data of all supported Vaults (past and present)
- [x] Getter for latest Vault address for token

TODO:
- [ ] Tests
- [ ] Docs