### PR TITLE
Change Rate Limit disable

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -876,7 +876,6 @@ def addStrategy(
         The fee the strategist will receive based on this Vault's performance.
     """
     assert _strategy != ZERO_ADDRESS
-    assert _rateLimit > 0
 
     assert msg.sender == self.governance
     assert self.strategies[_strategy].activation == 0
@@ -933,8 +932,6 @@ def updateStrategyRateLimit(
     @param _strategy The Strategy to update.
     @param _rateLimit The quantity of assets `_strategy` may now manage.
     """
-    assert _rateLimit > 0
-
     assert msg.sender == self.governance
     assert self.strategies[_strategy].activation > 0
     self.strategies[_strategy].rateLimit = _rateLimit
@@ -1123,8 +1120,8 @@ def _creditAvailable(_strategy: address) -> uint256:
     # Adjust by the rate limit algorithm (limits the step size per reporting period)
     delta: uint256 = block.timestamp - strategy_lastReport
     # NOTE: Protect against unnecessary overflow faults here
-    # NOTE: Set `strategy_rateLimit` to a really high number to disable the rate limit
-    if available / strategy_rateLimit >= delta:
+    # NOTE: Set `strategy_rateLimit` to 0 to disable the rate limit
+    if strategy_rateLimit > 0 and available / strategy_rateLimit >= delta:
         available = min(available, strategy_rateLimit * delta)
 
     # Can only borrow up to what the contract has in reserve

--- a/tests/functional/strategy/test_rate_limit.py
+++ b/tests/functional/strategy/test_rate_limit.py
@@ -1,0 +1,39 @@
+import pytest
+import brownie
+
+
+def test_simple_limit(chain, gov, vault, token, TestStrategy):
+    strategy = gov.deploy(TestStrategy, vault)
+    vault.addStrategy(strategy, 1000, 10, 0, {"from": gov})
+
+    token.approve(vault, 5000, {"from": gov})
+    vault.deposit(5000, {"from": gov})
+
+    # Mine a block in a second
+    start = chain.time()
+    chain.mine(1, start + 1)
+
+    assert token.balanceOf(strategy) == 0
+    strategy.harvest({"from": gov})
+    # Doing this because even if set the time of the block
+    # the clock keeps ticking while the code runs.
+    # a balance of 40 would mean that it took more than 4 secs
+    # to harvest
+    assert token.balanceOf(strategy) <= 40
+
+    # After a while the strategy will be able to get up to debtLimit
+    chain.mine(1, start + 1000)
+    strategy.harvest({"from": gov})
+    assert token.balanceOf(strategy) == 1000
+
+
+def test_zero_limit(chain, gov, vault, token, TestStrategy):
+    strategy = gov.deploy(TestStrategy, vault)
+    vault.addStrategy(strategy, 1000, 0, 0, {"from": gov})
+
+    token.approve(vault, 5000, {"from": gov})
+    vault.deposit(5000, {"from": gov})
+
+    assert token.balanceOf(strategy) == 0
+    strategy.harvest({"from": gov})
+    assert token.balanceOf(strategy) == 1000


### PR DESCRIPTION
Have `rateLimit = 0` explicitly shut off the rate limiter, instead of letting a large number implicitly disable it.

We were seeing test case issues because of the implicit check, as brownie tests execute too quickly for the implicit disable to work properly. An explicit disable is better, and avoids potential div / 0 faults from an improperly configured rate limit.

The new behavior is that 0 is disabled, and >0 is not

TODO:
- [x] Test w/ disable active