### PR TITLE
fix: div by zero

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -834,7 +834,7 @@ def pricePerShare() -> uint256:
     @return The value of a single share.
     """
     if self.totalSupply == 0:
-        return 0
+        return 10 ** self.decimals()  # price of 1:1
     else:
         return self._shareValue(10 ** self.decimals)
 

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -691,10 +691,7 @@ def deposit(_amount: uint256 = MAX_UINT256, _recipient: address = msg.sender) ->
 def _shareValue(_shares: uint256) -> uint256:
     # Determines the current value of `_shares`.
         # NOTE: if sqrt(Vault.totalAssets()) >>> 1e39, this could potentially revert
-    if self.totalSupply == 0:
-        return 0
-    else:
-        return (_shares * (self._totalAssets())) / self.totalSupply
+    return (_shares * (self._totalAssets())) / self.totalSupply
 
 
 @view
@@ -836,7 +833,10 @@ def pricePerShare() -> uint256:
     @dev See dev note on `withdraw`.
     @return The value of a single share.
     """
-    return self._shareValue(10 ** self.decimals)
+    if self.totalSupply == 0:
+        return 0
+    else:
+        return self._shareValue(10 ** self.decimals)
 
 
 @internal

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -691,7 +691,10 @@ def deposit(_amount: uint256 = MAX_UINT256, _recipient: address = msg.sender) ->
 def _shareValue(_shares: uint256) -> uint256:
     # Determines the current value of `_shares`.
         # NOTE: if sqrt(Vault.totalAssets()) >>> 1e39, this could potentially revert
-    return (_shares * (self._totalAssets())) / self.totalSupply
+    if self.totalSupply == 0:
+        return 0
+    else:
+        return (_shares * (self._totalAssets())) / self.totalSupply
 
 
 @view

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -834,7 +834,7 @@ def pricePerShare() -> uint256:
     @return The value of a single share.
     """
     if self.totalSupply == 0:
-        return 10 ** self.decimals()  # price of 1:1
+        return 10 ** self.decimals  # price of 1:1
     else:
         return self._shareValue(10 ** self.decimals)
 

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -30,6 +30,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.debtOutstanding() == 0
     assert vault.maxAvailableShares() == 0
     assert vault.totalAssets() == 0
+    assert vault.pricePerShare() == 0
 
 
 def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -30,7 +30,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.debtOutstanding() == 0
     assert vault.maxAvailableShares() == 0
     assert vault.totalAssets() == 0
-    assert vault.pricePerShare() / vault.decimals() == 1.0
+    assert vault.pricePerShare() / (10 ** vault.decimals()) == 1.0
 
 
 def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -30,7 +30,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.debtOutstanding() == 0
     assert vault.maxAvailableShares() == 0
     assert vault.totalAssets() == 0
-    assert vault.pricePerShare() == 0
+    assert vault.pricePerShare() / vault.decimals() == 1.0
 
 
 def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):


### PR DESCRIPTION
When the vault has no funds, `pricePerShare` reverts with a zero division.
That's because the external method calls `_shareValue` which does a division by `totalSuppy`.
