### PR TITLE
Store Vault activation timestamp

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -135,6 +135,7 @@ depositLimit: public(uint256)  # Limit for totalAssets the Vault can hold
 debtLimit: public(uint256)  # Debt limit for the Vault across all strategies
 totalDebt: public(uint256)  # Amount of tokens that all strategies have borrowed
 lastReport: public(uint256)  # block.timestamp of last report
+activation: public(uint256)  # block.timestamp of contract deployment
 
 rewards: public(address)  # Rewards contract where Governance fees are sent to
 # Governance Fee for management of Vault (given to `rewards`)
@@ -189,6 +190,7 @@ def __init__(
     self.managementFee = 200  # 2% per year
     self.depositLimit = MAX_UINT256  # Start unlimited
     self.lastReport = block.timestamp
+    self.activation = block.timestamp
 
 
 @pure


### PR DESCRIPTION
This could be used to make a universal GuestList which rate limits starting from the Vault deployment.