### PR TITLE
feat: add permit

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1434,7 +1434,7 @@ def permit(owner: address, spender: address, amount: uint256, expiry: uint256, s
     @param signature A valid secp256k1 signature of Permit by owner encoded as r, s, v.
     """
     assert owner != ZERO_ADDRESS  # dev: invalid owner
-    assert expiry >= block.timestamp  # dev: permit expired
+    assert expiry == 0 or expiry >= block.timestamp  # dev: permit expired
     nonce: uint256 = self.nonces[owner]
     digest: bytes32 = self.permit_digest(owner, spender, amount, nonce, expiry)
     # NOTE: signature is packed as r, s, v

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1411,6 +1411,7 @@ def permit(owner: address, spender: address, amount: uint256, expiry: uint256, s
     @param amount The amount of tokens to be spent.
     @param expiry The timestamp after which the Permit is no longer valid.
     @param signature A valid secp256k1 signature of Permit by owner encoded as r, s, v.
+    @return True, if transaction completes successfully
     """
     assert owner != ZERO_ADDRESS  # dev: invalid owner
     assert expiry == 0 or expiry >= block.timestamp  # dev: permit expired

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -143,6 +143,11 @@ managementFee: public(uint256)
 performanceFee: public(uint256)
 FEE_MAX: constant(uint256) = 10_000  # 100%, or 10k basis points
 SECS_PER_YEAR: constant(uint256) = 31_557_600  # 365.25 days
+# `nonces` track `permit` approvals with signature.
+nonces: public(HashMap[address, uint256])
+DOMAIN_SEPARATOR: public(bytes32)
+DOMAIN_TYPE_HASH: constant(bytes32) = keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)')
+PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 expiry)")
 
 
 @external
@@ -190,6 +195,16 @@ def __init__(
     self.depositLimit = MAX_UINT256  # Start unlimited
     self.lastReport = block.timestamp
     self.activation = block.timestamp
+    # EIP-712
+    self.DOMAIN_SEPARATOR = keccak256(
+        concat(
+            DOMAIN_TYPE_HASH,
+            keccak256(convert("Yearn Vault", Bytes[64])),
+            keccak256(convert(API_VERSION, Bytes[32])),
+            convert(chain.id, bytes32),
+            convert(self, bytes32)
+        )
+    )
 
 
 @pure
@@ -1382,3 +1397,54 @@ def sweep(_token: address, _value: uint256 = MAX_UINT256):
     if _value == MAX_UINT256:
         value = ERC20(_token).balanceOf(self)
     self.erc20_safe_transfer(_token, self.governance, value)
+
+
+
+@view
+@internal
+def permit_digest(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256) -> bytes32:
+    return keccak256(
+        concat(
+            b'\x19\x01',
+            self.DOMAIN_SEPARATOR,
+            keccak256(
+                concat(
+                    PERMIT_TYPE_HASH,
+                    convert(owner, bytes32),
+                    convert(spender, bytes32),
+                    convert(amount, bytes32),
+                    convert(nonce, bytes32),
+                    convert(expiry, bytes32),
+                )
+            )
+        )
+    )
+
+
+@external
+def permit(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256, signature: Bytes[65]) -> bool:
+    """
+    @notice
+        Approve the spender to expend the specified amount of owner's tokens by signature.
+        See https://eips.ethereum.org/EIPS/eip-2612.
+    
+    @param owner The address which has signed the Permit.
+    @param spender The address which is allowed to spend the funds.
+    @param amount The amount of tokens to be spent.
+    @param nonce The current nonce of the funds owner.
+    @param expiry The timestamp after which the Permit expires.
+    @param signature A valid secp256k1 signature encoded as r, s, v.
+    """
+    assert owner != ZERO_ADDRESS  # dev: invalid owner
+    assert expiry >= block.timestamp  # dev: permit expired
+    assert nonce == self.nonces[owner]  # dev: invalid nonce
+    digest: bytes32 = self.permit_digest(owner, spender, amount, nonce, expiry)
+    # NOTE: signature is packed as r, s, v
+    r: uint256 = convert(slice(signature, 0, 32), uint256)
+    s: uint256 = convert(slice(signature, 32, 32), uint256)
+    v: uint256 = convert(slice(signature, 64, 1), uint256)
+    assert ecrecover(digest, v, r, s) == owner  # dev: invalid signature
+    self.allowance[owner][spender] = amount
+    self.nonces[owner] += 1
+    log Approval(owner, spender, amount)
+    return True

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -199,8 +199,8 @@ def __init__(
     self.DOMAIN_SEPARATOR = keccak256(
         concat(
             DOMAIN_TYPE_HASH,
-            keccak256(convert("Yearn Vault", Bytes[64])),
-            keccak256(convert(API_VERSION, Bytes[32])),
+            keccak256(convert("Yearn Vault", Bytes[11])),
+            keccak256(convert(API_VERSION, Bytes[28])),
             convert(chain.id, bytes32),
             convert(self, bytes32)
         )
@@ -1401,7 +1401,7 @@ def sweep(_token: address, _value: uint256 = MAX_UINT256):
 
 @view
 @internal
-def permit_digest(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256) -> bytes32:
+def _permitDigest(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256) -> bytes32:
     return keccak256(
         concat(
             b'\x19\x01',
@@ -1443,6 +1443,6 @@ def permit(owner: address, spender: address, amount: uint256, expiry: uint256, s
     v: uint256 = convert(slice(signature, 64, 1), uint256)
     assert ecrecover(digest, v, r, s) == owner  # dev: invalid signature
     self.allowance[owner][spender] = amount
-    self.nonces[owner] += 1
+    self.nonces[owner] = nonce + 1
     log Approval(owner, spender, amount)
     return True

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1421,7 +1421,7 @@ def permit_digest(owner: address, spender: address, amount: uint256, nonce: uint
 
 
 @external
-def permit(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256, signature: Bytes[65]) -> bool:
+def permit(owner: address, spender: address, amount: uint256, expiry: uint256, signature: Bytes[65]) -> bool:
     """
     @notice
         Approves spender by owner's signature to expend owner's tokens.
@@ -1430,13 +1430,12 @@ def permit(owner: address, spender: address, amount: uint256, nonce: uint256, ex
     @param owner The address which is a source of funds and has signed the Permit.
     @param spender The address which is allowed to spend the funds.
     @param amount The amount of tokens to be spent.
-    @param nonce The current nonce of the owner.
     @param expiry The timestamp after which the Permit is no longer valid.
     @param signature A valid secp256k1 signature of Permit by owner encoded as r, s, v.
     """
     assert owner != ZERO_ADDRESS  # dev: invalid owner
     assert expiry >= block.timestamp  # dev: permit expired
-    assert nonce == self.nonces[owner]  # dev: invalid nonce
+    nonce: uint256 = self.nonces[owner]
     digest: bytes32 = self.permit_digest(owner, spender, amount, nonce, expiry)
     # NOTE: signature is packed as r, s, v
     r: uint256 = convert(slice(signature, 0, 32), uint256)

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1399,7 +1399,6 @@ def sweep(_token: address, _value: uint256 = MAX_UINT256):
     self.erc20_safe_transfer(_token, self.governance, value)
 
 
-
 @view
 @internal
 def permit_digest(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256) -> bytes32:
@@ -1425,15 +1424,15 @@ def permit_digest(owner: address, spender: address, amount: uint256, nonce: uint
 def permit(owner: address, spender: address, amount: uint256, nonce: uint256, expiry: uint256, signature: Bytes[65]) -> bool:
     """
     @notice
-        Approve the spender to expend the specified amount of owner's tokens by signature.
+        Approves spender by owner's signature to expend owner's tokens.
         See https://eips.ethereum.org/EIPS/eip-2612.
     
-    @param owner The address which has signed the Permit.
+    @param owner The address which is a source of funds and has signed the Permit.
     @param spender The address which is allowed to spend the funds.
     @param amount The amount of tokens to be spent.
-    @param nonce The current nonce of the funds owner.
-    @param expiry The timestamp after which the Permit expires.
-    @param signature A valid secp256k1 signature encoded as r, s, v.
+    @param nonce The current nonce of the owner.
+    @param expiry The timestamp after which the Permit is no longer valid.
+    @param signature A valid secp256k1 signature of Permit by owner encoded as r, s, v.
     """
     assert owner != ZERO_ADDRESS  # dev: invalid owner
     assert expiry >= block.timestamp  # dev: permit expired

--- a/tests/functional/vault/test_permit.py
+++ b/tests/functional/vault/test_permit.py
@@ -46,7 +46,5 @@ def test_permit(vault):
     message = encode_structured_data(data)
     signed = owner.sign_message(message)
     assert vault.allowance(owner.address, spender.address) == 0
-    vault.permit(
-        owner.address, spender.address, amount, nonce, expiry, signed.signature
-    )
+    vault.permit(owner.address, spender.address, amount, expiry, signed.signature)
     assert vault.allowance(owner.address, spender.address) == amount

--- a/tests/functional/vault/test_permit.py
+++ b/tests/functional/vault/test_permit.py
@@ -64,7 +64,7 @@ def test_permit_wrong_signature(vault):
     permit = generate_permit(vault, owner, spender, amount, nonce, expiry)
     signature = spender.sign_message(permit).signature
     assert vault.allowance(owner.address, spender.address) == 0
-    with brownie.reverts('dev: invalid signature'):
+    with brownie.reverts("dev: invalid signature"):
         vault.permit(owner.address, spender.address, amount, expiry, signature)
 
 
@@ -74,5 +74,5 @@ def test_permit_expired(vault):
     permit = generate_permit(vault, owner, spender, amount, nonce, expiry)
     signature = owner.sign_message(permit).signature
     assert vault.allowance(owner.address, spender.address) == 0
-    with brownie.reverts('dev: permit expired'):
+    with brownie.reverts("dev: permit expired"):
         vault.permit(owner.address, spender.address, amount, expiry, signature)

--- a/tests/functional/vault/test_permit.py
+++ b/tests/functional/vault/test_permit.py
@@ -12,6 +12,7 @@ spender = Account.create()
 def generate_permit(vault, owner: Account, spender: Account, amount, nonce, expiry):
     name = "Yearn Vault"
     version = vault.apiVersion()
+    chain_id = 1  # ganache bug https://github.com/trufflesuite/ganache/issues/1643
     contract = str(vault)
     data = {
         "types": {
@@ -32,7 +33,7 @@ def generate_permit(vault, owner: Account, spender: Account, amount, nonce, expi
         "domain": {
             "name": name,
             "version": version,
-            "chainId": 1,
+            "chainId": chain_id,
             "verifyingContract": contract,
         },
         "primaryType": "Permit",

--- a/tests/functional/vault/test_permit.py
+++ b/tests/functional/vault/test_permit.py
@@ -1,0 +1,52 @@
+from brownie import chain
+from eth_account import Account
+from eth_account._utils.structured_data.hashing import hash_domain
+from eth_account.messages import encode_structured_data
+from eth_utils import encode_hex
+
+
+def test_permit(vault):
+    owner = Account.create()
+    spender = Account.create()
+    nonce = vault.nonces(owner.address)
+    expiry = chain[-1].timestamp + 3600
+    amount = 10 ** 21
+    data = {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Permit": [
+                {"name": "owner", "type": "address"},
+                {"name": "spender", "type": "address"},
+                {"name": "amount", "type": "uint256"},
+                {"name": "nonce", "type": "uint256"},
+                {"name": "expiry", "type": "uint256"},
+            ],
+        },
+        "domain": {
+            "name": "Yearn Vault",
+            "version": vault.apiVersion(),
+            "chainId": 1,
+            "verifyingContract": str(vault),
+        },
+        "primaryType": "Permit",
+        "message": {
+            "owner": owner.address,
+            "spender": spender.address,
+            "amount": amount,
+            "nonce": nonce,
+            "expiry": expiry,
+        },
+    }
+    assert encode_hex(hash_domain(data)) == vault.DOMAIN_SEPARATOR()
+    message = encode_structured_data(data)
+    signed = owner.sign_message(message)
+    assert vault.allowance(owner.address, spender.address) == 0
+    vault.permit(
+        owner.address, spender.address, amount, nonce, expiry, signed.signature
+    )
+    assert vault.allowance(owner.address, spender.address) == amount


### PR DESCRIPTION
Implement `permit` approval by signature.

Inspired by [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612) draft, but doesn't follow it verbatim.

Notable deviations:
- EIP-712 domain `name` is fixed as `Yearn Vault` since contract name is mutable.
- EIP-712 domain `version` is read from `apiVersion`.
- `Permit` message uses `amount` instead of `value` as argument name because `value` is reserved in Vyper.
- Signature is encoded as `Bytes[65]` of packed `r, s, v` instead of three args.
- The function returns True, this part is arguable, since it's is unclear from the spec.

References:
- [Uniswap](https://github.com/Uniswap/uniswap-v2-core/blob/4dd59067c76dea4a0e8e4bfdda41877a6b16dedc/contracts/UniswapV2ERC20.sol#L81)
- [DAI](https://github.com/makerdao/dss/blob/36dab5c9fdce4fc36812e4fd8228be3beb18774d/src/dai.sol#L120)
- [USDC](https://github.com/centrehq/centre-tokens/blob/5013157edecbaf5da7fb9e3afa85992965077c88/contracts/v2/Permit.sol#L68)