### PR TITLE
explicity check for migration success

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -602,7 +602,7 @@ abstract contract BaseStrategy {
      * transferring any reserve or LP tokens, CDPs, or other tokens or stores of
      * value.
      */
-    function prepareMigration(address _newStrategy) internal virtual;
+    function executeMigration(address _newStrategy) internal virtual returns (bool _success);
 
     /**
      * @notice
@@ -616,7 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
-        prepareMigration(_newStrategy);
+        require(executeMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }
 

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -616,7 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
-        // Explicitly require a migration success signal from the implementers of `prepareMigration`
+        // Explicitly require a migration success signal from the implementer of `prepareMigration`
         require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -616,7 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
-        // Explicitly require a migration success signal from implementers of `prepareMigration`
+        // Explicitly require a migration success signal from the implementers of `prepareMigration`
         require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -602,7 +602,7 @@ abstract contract BaseStrategy {
      * transferring any reserve or LP tokens, CDPs, or other tokens or stores of
      * value.
      */
-    function executeMigration(address _newStrategy) internal virtual returns (bool _success);
+    function prepareMigration(address _newStrategy) internal virtual returns (bool _success);
 
     /**
      * @notice
@@ -616,7 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
-        require(executeMigration(_newStrategy));
+        require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }
 

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -616,6 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
+        // Explicitly require a migration success signal from implementers of `prepareMigration`
         require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -616,6 +616,7 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
+        // Explicitly require a success signal from `prepareMigration` implementer
         require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -616,7 +616,6 @@ abstract contract BaseStrategy {
     function migrate(address _newStrategy) external {
         require(msg.sender == address(vault) || msg.sender == governance());
         require(BaseStrategy(_newStrategy).vault() == vault);
-        // Explicitly require a success signal from `prepareMigration` implementer
         require(prepareMigration(_newStrategy));
         want.transfer(_newStrategy, want.balanceOf(address(this)));
     }

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -88,8 +88,9 @@ contract TestStrategy is BaseStrategy {
         }
     }
 
-    function prepareMigration(address _newStrategy) internal override {
+    function prepareMigration(address _newStrategy) internal override returns (bool _success){
         // Nothing needed here because no additional tokens/tokenized positions for mock
+        return true;
     }
 
     function protectedTokens() internal override view returns (address[] memory) {


### PR DESCRIPTION
`require()` that `prepareMigration` explicitly signals its success before `transfer()`ing `want` 