### PR TITLE
feat: simplified vault registry

### DIFF
--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -7,6 +7,7 @@
 - Vault: Only user touch-point, manages funds
 - Strategy: Complex external interactions w/ limited access to Vault
 - Strategist: original creator of strategy, is in charge of monitoring its position for adverse effects.
+- Registry: On-chain registry of deployed Vaults for tokens, indexed by API version
 
 ## Vault Specification
 
@@ -71,6 +72,18 @@ NOTE: In this mode, the Strategy defines a reversionary set of actions that seek
 1. During Emergency Exit, the Strategy cannot take new debt from the connected Vault.
 1. During Emergency Exit, the Strategy can still interact with any external system, but must be able to handle any failure(s) of each of those system(s) as well as possible.
 1. Only Governance can exit Emergency Exit Mode.
+
+## Registry Specification
+
+### Normal Operation
+
+NOTE: The Registry allows an on-chain reference for Vault deployment events, to be used with external integrations. It is also possible to reconstruct the deployment and release history via on-chain calls.
+
+NOTE: The API version of each Vault deployment for a token should increase according to [Semantic Versioning](https://semver.org/). However, this is not practically enforced.
+
+1. Only Governance can register a new release for future Vaults to use when deploying via proxy deployment.
+1. Anyone can deploy a proxy deployment Vault, using the latest release, for experimental purposes
+1. Only Governance can endorse a Vault deployment for a given token with the latest release.
 
 ## Governance Specification
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -12,6 +12,7 @@ interface Vault:
     def initialize(
         token: address,
         governance: address,
+        rewards: address,
         name: String[64],
         symbol: String[32],
         guardian: address,
@@ -122,6 +123,7 @@ def newRelease(vault: address):
 def newVault(
     token: address,
     guardian: address,
+    rewards: address,
     nameOverride: String[64] = "",
     symbolOverride: String[32] = "",
 ) -> address:
@@ -137,6 +139,7 @@ def newVault(
         of `token`.
     @param token The token that may be deposited into this Vault.
     @param guardian The address authorized for guardian interactions.
+    @param rewards The address to use for collecting rewards.
     @param nameOverride Specify a custom Vault name. Leave empty for default choice.
     @param symbolOverride Specify a custom Vault symbol name. Leave empty for default choice.
     @return The address of the newly-deployed vault
@@ -155,7 +158,7 @@ def newVault(
         symbol = concat("yv", DetailedERC20(token).symbol())
 
     # NOTE: Must initialize the Vault atomically with deploying it
-    Vault(vault).initialize(token, msg.sender, name, symbol, guardian)
+    Vault(vault).initialize(token, msg.sender, rewards, name, symbol, guardian)
 
     self._addVault(token, vault)
 
@@ -167,6 +170,7 @@ def newExperimentalVault(
     token: address,
     governance: address = msg.sender,
     guardian: address = msg.sender,
+    rewards: address = msg.sender,
     nameOverride: String[64] = "",
     symbolOverride: String[32] = "",
 ) -> address:
@@ -184,7 +188,7 @@ def newExperimentalVault(
         symbol = concat("yv", DetailedERC20(token).symbol())
 
     # NOTE: Must initialize the Vault atomically with deploying it
-    Vault(vault).initialize(token, governance, name, symbol, guardian)
+    Vault(vault).initialize(token, governance, rewards, name, symbol, guardian)
 
     log NewExperimentalVault(token, vault, Vault(release_template).apiVersion())
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -47,6 +47,7 @@ event NewVault:
 
 event NewExperimentalVault:
     token: indexed(address)
+    deployer: indexed(address)
     vault: address
     api_version: String[28]
 
@@ -217,7 +218,7 @@ def newExperimentalVault(
     Vault(vault).initialize(token, governance, rewards, name, symbol, guardian)
 
     # NOTE: Don't add to list of endorsed vaults (hence no event there, so we emit here)
-    log NewExperimentalVault(token, vault, Vault(release_template).apiVersion())
+    log NewExperimentalVault(token, msg.sender, vault, Vault(release_template).apiVersion())
 
     return vault
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -31,7 +31,7 @@ vaults: public(HashMap[address, HashMap[uint256, address]])
 governance: public(address)
 pendingGovernance: address
 
-tags: public(HashMap[address, String[1000000]])
+tags: public(HashMap[address, String[120]])
 banksy: public(HashMap[address, bool])  # could be anyone
 
 event NewRelease:
@@ -56,7 +56,7 @@ event NewGovernance:
 
 event VaultTagged:
     vault: address
-    tag: String[1000000]
+    tag: String[120]
 
 @external
 def __init__():
@@ -309,7 +309,7 @@ def setBanksy(tagger: address, allowed: bool = True):
 
 
 @external
-def tagVault(vault: address, tag: String[1000000]):
+def tagVault(vault: address, tag: String[120]):
     """
     @notice Tag a Vault with a message.
     @dev

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -193,8 +193,15 @@ def newVault(
     assert msg.sender == self.governance  # dev: unauthorized
 
     # NOTE: Underflow if no releases created yet (this is okay)
-    release_template: address = self.releases[self.nextRelease - 1]  # dev: no releases
-    vault: address = self._newVault(token, release_template, msg.sender, msg.sender, guardian, name, symbol)
+    vault: address = self._newVault(
+        token,
+        self.releases[self.nextRelease - 1],  # dev: no releases
+        msg.sender,  # self.governance
+        rewards,
+        guardian,
+        name,
+        symbol,
+    )
 
     self._endorseVault(token, vault)
 
@@ -211,14 +218,22 @@ def newExperimentalVault(
     symbol: String[32],
 ) -> address:
     # NOTE: Anyone can call this method, as a convenience to Strategist' experiments
+
     # NOTE: Underflow if no releases created yet (this is okay)
-    release_template: address = self.releases[self.nextRelease - 1]  # dev: no releases
-    vault: address = self._newVault(token, release_template, governance, governance, guardian, name, symbol)
+    vault: address = self._newVault(
+        token,
+        self.releases[self.nextRelease - 1],  # dev: no releases
+        governance,
+        rewards,
+        guardian,
+        name,
+        symbol,
+    )
     # NOTE: Must initialize the Vault atomically with deploying it
     Vault(vault).initialize(token, governance, rewards, name, symbol, guardian)
 
     # NOTE: Don't add to list of endorsed vaults (hence no event there, so we emit here)
-    log NewExperimentalVault(token, msg.sender, vault, Vault(release_template).apiVersion())
+    log NewExperimentalVault(token, msg.sender, vault, Vault(vault).apiVersion())
 
     return vault
 

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -114,14 +114,14 @@ def latestVault(token: address) -> address:
 
 @internal
 def _registerRelease(vault: address):
-    api_version: String[28] = Vault(vault).apiVersion()
-
     # Check if the release is different from the current one
     # NOTE: This doesn't check for strict semver-style linearly increasing release versions
     release_id: uint256 = self.nextRelease  # Next id in series
     if release_id > 0:
-        current_version: String[28] = Vault(self.releases[release_id - 1]).apiVersion()
-        assert current_version != api_version  # dev: same api version
+        assert (
+            Vault(self.releases[release_id - 1]).apiVersion()
+            != Vault(vault).apiVersion()
+        )  # dev: same api version
     # else: we are adding the first release to the Registry!
 
     # Update latest release
@@ -129,19 +129,19 @@ def _registerRelease(vault: address):
     self.nextRelease = release_id + 1
 
     # Log the release for external listeners (e.g. Graph)
-    log NewRelease(release_id, vault, api_version)
+    log NewRelease(release_id, vault, Vault(vault).apiVersion())
 
 
 @internal
 def _registerDeployment(token: address, vault: address):
-    api_version: String[28] = Vault(vault).apiVersion()
-
     # Check if there is an existing deployment for this token at the particular api version
     # NOTE: This doesn't check for strict semver-style linearly increasing release versions
     deployment_id: uint256 = self.nextDeployment[token]  # Next id in series
     if deployment_id > 0:
-        current_version: String[28] = Vault(self.vaults[token][deployment_id - 1]).apiVersion()
-        assert current_version != api_version  # dev: same api version
+        assert (
+            Vault(self.vaults[token][deployment_id - 1]).apiVersion()
+            != Vault(vault).apiVersion()
+        )  # dev: same api version
     # else: we are adding a new token to the Registry
 
     # Update the latest deployment
@@ -149,7 +149,7 @@ def _registerDeployment(token: address, vault: address):
     self.nextDeployment[token] = deployment_id + 1
 
     # Log the deployment for external listeners (e.g. Graph)
-    log NewVault(token, deployment_id, vault, api_version)
+    log NewVault(token, deployment_id, vault, Vault(vault).apiVersion())
 
 
 @external

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -152,7 +152,7 @@ def _newVault(
 
     nameOverride: String[64] = name
     if nameOverride == "":
-        nameOverride = concat("Yearn ", DetailedERC20(token).name(), " Vault")
+        nameOverride = concat(DetailedERC20(token).symbol(), " yVault")
 
     symbolOverride: String[32] = symbol
     if symbolOverride == "":

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -1,0 +1,214 @@
+# @version 0.2.8
+
+interface DetailedERC20:
+    def name() -> String[52]: view
+    def symbol() -> String[30]: view
+
+
+interface Vault:
+    def token() -> address: view
+    def apiVersion() -> String[28]: view
+    def governance() -> address: view
+    def initialize(
+        token: address,
+        governance: address,
+        name: String[64],
+        symbol: String[32],
+        guardian: address,
+    ): nonpayable
+
+
+# len(Vault.releases)
+nextRelease: public(uint256)
+releases: public(HashMap[uint256, address])
+
+# Token.address => len(Vault.deployments)
+nextDeployment: public(HashMap[address, uint256])
+vaults: public(HashMap[address, HashMap[uint256, address]])
+
+# 2-phase commit
+governance: public(address)
+pendingGovernance: address
+
+
+event NewRelease:
+    release_id: indexed(uint256)
+    template: address
+    api_version: String[28]
+
+event NewVault:
+    token: indexed(address)
+    deployment_id: indexed(uint256)
+    vault: address
+    api_version: String[28]
+
+event NewExperimentalVault:
+    token: indexed(address)
+    vault: address
+    api_version: String[28]
+
+event NewGovernance:
+    governance: address
+
+@external
+def __init__():
+    self.governance = msg.sender
+
+
+@external
+def setGovernance(governance: address):
+    assert msg.sender == self.governance  # dev: unauthorized
+    self.pendingGovernance = governance
+
+
+@external
+def acceptGovernance():
+    assert msg.sender == self.pendingGovernance  # dev: unauthorized
+    self.governance = msg.sender
+    log NewGovernance(msg.sender)
+
+
+@view
+@external
+def latestRelease() -> String[28]:
+    # NOTE: Throws if there has not been a release yet
+    return Vault(self.releases[self.nextRelease - 1]).apiVersion()  # dev: no release
+
+
+@view
+@external
+def latestVault(token: address) -> address:
+    # NOTE: Throws if there has not been a deployment yet for this token
+    return self.vaults[token][self.nextDeployment[token] - 1]  # dev: no vault for token
+
+
+@internal
+def _addVault(token: address, vault: address):
+    deployment_id: uint256 = self.nextDeployment[token]  # Next id in series
+    self.vaults[token][deployment_id] = vault
+    self.nextDeployment[token] = deployment_id + 1
+
+    log NewVault(token, deployment_id, vault, Vault(vault).apiVersion())
+
+
+@external
+def newRelease(vault: address):
+    """
+    @notice
+        Add a previously deployed Vault as a vault for a particular release
+    @dev
+        The Vault must be a valid Vault, and should be the next in the release series, meaning
+        semver is being followed. The code does not check for that, only that the release is not
+        the same as the previous one.
+    @param vault The deployed Vault to use as the cornerstone template for the given release.
+    """
+    assert msg.sender == self.governance  # dev: unauthorized
+
+    release_id: uint256 = self.nextRelease  # Next id in series
+    api_version: String[28] = Vault(vault).apiVersion()
+    if release_id > 0:
+        assert Vault(self.releases[release_id - 1]).apiVersion() != api_version  # dev: same version
+
+    self.releases[release_id] = vault
+    self.nextRelease = release_id + 1
+
+    log NewRelease(release_id, vault, api_version)
+
+    # Also register the release as a new Vault
+    self._addVault(Vault(vault).token(), vault)
+
+
+@external
+def newVault(
+    token: address,
+    guardian: address,
+    nameOverride: String[64] = "",
+    symbolOverride: String[32] = "",
+) -> address:
+    """
+    @notice
+        Add a new deployed vault for the given token as a simple "forwarder-style" proxy to the
+        latest version being managed by this registry
+    @dev
+        If `nameOverride` is not specified, the name will be 'yearn' combined with the name of
+        `token`.
+
+        If `symbolOverride` is not specified, the symbol will be 'yv' combined with the symbol
+        of `token`.
+    @param token The token that may be deposited into this Vault.
+    @param guardian The address authorized for guardian interactions.
+    @param nameOverride Specify a custom Vault name. Leave empty for default choice.
+    @param symbolOverride Specify a custom Vault symbol name. Leave empty for default choice.
+    @return The address of the newly-deployed vault
+    """
+    assert msg.sender == self.governance  # dev: unauthorized
+
+    # NOTE: Underflow if no releases created yet (this is okay)
+    vault: address = create_forwarder_to(self.releases[self.nextRelease - 1])
+
+    name: String[64] = nameOverride
+    if name == "":
+        name = concat("Yearn ", DetailedERC20(token).name(), " Vault")
+
+    symbol: String[32] = symbolOverride
+    if symbol == "":
+        symbol = concat("yv", DetailedERC20(token).symbol())
+
+    # NOTE: Must initialize the Vault atomically with deploying it
+    Vault(vault).initialize(token, msg.sender, name, symbol, guardian)
+
+    self._addVault(token, vault)
+
+    return vault
+
+
+@external
+def newExperimentalVault(
+    token: address,
+    governance: address = msg.sender,
+    guardian: address = msg.sender,
+    nameOverride: String[64] = "",
+    symbolOverride: String[32] = "",
+) -> address:
+    # NOTE: Anyone can call this method, as a convenience to Strategist' experiments
+    # NOTE: Underflow if no releases created yet (this is okay)
+    release_template: address = self.releases[self.nextRelease - 1]
+    vault: address = create_forwarder_to(release_template)
+
+    name: String[64] = nameOverride
+    if name == "":
+        name = concat("Yearn ", DetailedERC20(token).name(), " Vault")
+
+    symbol: String[32] = symbolOverride
+    if symbol == "":
+        symbol = concat("yv", DetailedERC20(token).symbol())
+
+    # NOTE: Must initialize the Vault atomically with deploying it
+    Vault(vault).initialize(token, governance, name, symbol, guardian)
+
+    log NewExperimentalVault(token, vault, Vault(release_template).apiVersion())
+
+    return vault
+
+
+@external
+def endorseVault(vault: address):
+    assert msg.sender == self.governance  # dev: unauthorized
+    # NOTE: Underflow if no releases created yet (this is okay)
+    latest_version: String[28] = Vault(self.releases[self.nextRelease - 1]).apiVersion()
+    assert Vault(vault).apiVersion() == latest_version  # dev: not latest release
+
+    assert Vault(vault).governance() == msg.sender  # dev: unauthorized
+
+    # Check if there is an existing deployed vault for this token, and that we are not overwriting
+    # NOTE: This doesn't check for strict semver-style linearly increasing release versions
+    token: address = Vault(vault).token()
+    nextDeployment: uint256 = self.nextDeployment[token]
+    if nextDeployment > 0:
+        current_version: String[28] = Vault(self.vaults[token][nextDeployment - 1]).apiVersion()
+        assert current_version != latest_version  # dev: cannot override current version
+    # else: we are adding a new asset to the ecosystem!
+    #       (typically after a successful "experimental" vault)
+
+    # Add to the end of the list of vaults for token
+    self._addVault(token, vault)

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -31,6 +31,8 @@ vaults: public(HashMap[address, HashMap[uint256, address]])
 governance: public(address)
 pendingGovernance: address
 
+tags: public(HashMap[address, String[1000000]])
+banksy: public(HashMap[address, bool])  # could be anyone
 
 event NewRelease:
     release_id: indexed(uint256)
@@ -50,6 +52,10 @@ event NewExperimentalVault:
 
 event NewGovernance:
     governance: address
+
+event VaultTagged:
+    vault: address
+    tag: String[1000000]
 
 @external
 def __init__():
@@ -230,3 +236,18 @@ def endorseVault(vault: address):
 
     # Add to the end of the list of vaults for token
     self._endorseVault(token, vault)
+
+
+@external
+def setBanksy(tagger: address, allowed: bool = True):
+    assert msg.sender == self.governance  # dev: unauthorized
+    self.banksy[tagger] = allowed
+
+
+@external
+def tagVault(vault: address, tag: String[1000000]):
+    if msg.sender != self.governance:
+        assert self.banksy[msg.sender]  # dev: not banksy
+    # else: we are governance, we can do anything banksy can do
+    self.tags[vault] = tag
+    log VaultTagged(vault, tag)

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -163,7 +163,6 @@ def newRelease(vault: address):
         Throws if caller isn't `self.governance`.
         Throws if `vault`'s governance isn't `self.governance`.
         Throws if the api version is the same as the previous release.
-        Throws if there already is a deployment for the given token with the latest api version.
         Emits a `NewVault` event.
     @param vault The vault that will be used as the template contract for the next release.
     """
@@ -171,7 +170,7 @@ def newRelease(vault: address):
     assert Vault(vault).governance() == msg.sender  # dev: not governed
 
     self._registerRelease(vault)
-    self._registerDeployment(Vault(vault).token(), vault)
+    self._registerDeployment(Vault(vault).token(), vault)  # NOTE: Should never throw
 
 
 @internal

--- a/contracts/Registry.vy
+++ b/contracts/Registry.vy
@@ -1,9 +1,5 @@
 # @version 0.2.8
 
-interface DetailedERC20:
-    def name() -> String[52]: view
-    def symbol() -> String[30]: view
-
 
 interface Vault:
     def token() -> address: view
@@ -185,16 +181,8 @@ def _newProxyVault(
     # NOTE: Underflow if no releases created yet (this is okay)
     vault: address = create_forwarder_to(self.releases[self.nextRelease - 1])  # dev: no releases
 
-    nameOverride: String[64] = name
-    if nameOverride == "":
-        nameOverride = concat(DetailedERC20(token).symbol(), " yVault")
-
-    symbolOverride: String[32] = symbol
-    if symbolOverride == "":
-        symbolOverride = concat("yv", DetailedERC20(token).symbol())
-
     # NOTE: Must initialize the Vault atomically with deploying it
-    Vault(vault).initialize(token, governance, rewards, nameOverride, symbolOverride, guardian)
+    Vault(vault).initialize(token, governance, rewards, name, symbol, guardian)
 
     return vault
 

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -44,8 +44,6 @@ implements: ERC20
 
 
 interface DetailedERC20:
-    def name() -> String[42]: view
-    def symbol() -> String[20]: view
     def decimals() -> uint256: view
 
 
@@ -227,12 +225,12 @@ PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address sp
 
 
 @external
-def __init__(
-    token: address,
-    governance: address,
-    rewards: address,
-    nameOverride: String[64],
-    symbolOverride: String[32],
+def initialize(
+    _token: address,
+    _governance: address,
+    _name: String[64],
+    _symbol: String[32],
+    _guardian: address = msg.sender,
 ):
     """
     @notice
@@ -241,29 +239,18 @@ def __init__(
         The performance fee is set to 10% of yield, per Strategy.
         The management fee is set to 2%, per year.
         There is no initial deposit limit.
-    @dev
-        If `nameOverride` is not specified, the name will be 'yearn'
-        combined with the name of `token`.
-
-        If `symbolOverride` is not specified, the symbol will be 'y'
-        combined with the symbol of `token`.
     @param token The token that may be deposited into this Vault.
     @param governance The address authorized for governance interactions.
     @param rewards The address to distribute rewards to.
-    @param nameOverride Specify a custom Vault name. Leave empty for default choice.
-    @param symbolOverride Specify a custom Vault symbol name. Leave empty for default choice.
+    @param name Specify a custom Vault name.
+    @param symbol Specify a custom Vault symbol name.
     """
-    self.token = ERC20(token)
-    if nameOverride == "":
-        self.name = concat(DetailedERC20(token).symbol(), " yVault")
-    else:
-        self.name = nameOverride
-    if symbolOverride == "":
-        self.symbol = concat("yv", DetailedERC20(token).symbol())
-    else:
-        self.symbol = symbolOverride
-    self.decimals = DetailedERC20(token).decimals()
-    self.governance = governance
+    assert self.token == ERC20(ZERO_ADDRESS)  # NOTE: Ensures this can only be called once
+    self.token = ERC20(_token)
+    self.name = _name
+    self.symbol = _symbol
+    self.decimals = DetailedERC20(_token).decimals()
+    self.governance = _governance
     log UpdateGovernance(governance)
     self.management = governance
     log UpdateManagement(governance)

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -226,11 +226,12 @@ PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address sp
 
 @external
 def initialize(
-    _token: address,
-    _governance: address,
-    _name: String[64],
-    _symbol: String[32],
-    _guardian: address = msg.sender,
+    token: address,
+    governance: address,
+    rewards: address,
+    name: String[64],
+    symbol: String[32],
+    guardian: address = msg.sender,
 ):
     """
     @notice
@@ -244,20 +245,21 @@ def initialize(
     @param rewards The address to distribute rewards to.
     @param name Specify a custom Vault name.
     @param symbol Specify a custom Vault symbol name.
+    @param guardian The address authorized for guardian interactions. Defaults to caller.
     """
-    assert self.token == ERC20(ZERO_ADDRESS)  # NOTE: Ensures this can only be called once
-    self.token = ERC20(_token)
-    self.name = _name
-    self.symbol = _symbol
-    self.decimals = DetailedERC20(_token).decimals()
-    self.governance = _governance
+    assert self.activation == 0  # dev: no devops199
+    self.token = ERC20(token)
+    self.name = name
+    self.symbol = symbol
+    self.decimals = DetailedERC20(token).decimals()
+    self.governance = governance
     log UpdateGovernance(governance)
     self.management = governance
     log UpdateManagement(governance)
     self.rewards = rewards
     log UpdateRewards(rewards)
-    self.guardian = msg.sender
-    log UpdateGuardian(msg.sender)
+    self.guardian = guardian
+    log UpdateGuardian(guardian)
     self.performanceFee = 1000  # 10% of yield (per Strategy)
     log UpdatePerformanceFee(convert(1000, uint256))
     self.managementFee = 200  # 2% per year

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -44,6 +44,8 @@ implements: ERC20
 
 
 interface DetailedERC20:
+    def name() -> String[42]: view
+    def symbol() -> String[20]: view
     def decimals() -> uint256: view
 
 
@@ -229,8 +231,8 @@ def initialize(
     token: address,
     governance: address,
     rewards: address,
-    name: String[64],
-    symbol: String[32],
+    nameOverride: String[64],
+    symbolOverride: String[32],
     guardian: address = msg.sender,
 ):
     """
@@ -240,17 +242,29 @@ def initialize(
         The performance fee is set to 10% of yield, per Strategy.
         The management fee is set to 2%, per year.
         There is no initial deposit limit.
+    @dev
+        If `nameOverride` is not specified, the name will be 'yearn'
+        combined with the name of `token`.
+
+        If `symbolOverride` is not specified, the symbol will be 'y'
+        combined with the symbol of `token`.
     @param token The token that may be deposited into this Vault.
     @param governance The address authorized for governance interactions.
     @param rewards The address to distribute rewards to.
-    @param name Specify a custom Vault name.
-    @param symbol Specify a custom Vault symbol name.
+    @param nameOverride Specify a custom Vault name. Leave empty for default choice.
+    @param symbolOverride Specify a custom Vault symbol name. Leave empty for default choice.
     @param guardian The address authorized for guardian interactions. Defaults to caller.
     """
     assert self.activation == 0  # dev: no devops199
     self.token = ERC20(token)
-    self.name = name
-    self.symbol = symbol
+    if nameOverride == "":
+        self.name = concat(DetailedERC20(token).symbol(), " yVault")
+    else:
+        self.name = nameOverride
+    if symbolOverride == "":
+        self.symbol = concat("yv", DetailedERC20(token).symbol())
+    else:
+        self.symbol = symbolOverride
     self.decimals = DetailedERC20(token).decimals()
     self.governance = governance
     log UpdateGovernance(governance)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,32 @@
+from functools import lru_cache
+from pathlib import Path
+
 import pytest
+import yaml
+
+from brownie import compile_source, Vault
+
+PACKAGE_VERSION = yaml.safe_load(
+    (Path(__file__).parents[1] / "ethpm-config.yaml").read_text()
+)["version"]
+
+
+VAULT_SOURCE_CODE = (Path(__file__).parents[1] / "contracts/Vault.vy").read_text()
+
+
+@pytest.fixture
+def patch_vault_version():
+    # NOTE: Cache this result so as not to trigger a recompile for every version change
+    @lru_cache
+    def patch_vault_version(version):
+        if version is None:
+            return Vault
+        else:
+            source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
+            return compile_source(source).Vyper
+
+    return patch_vault_version
+
 
 # Function scoped isolation fixture to enable xdist.
 # Snapshots the chain before each test and reverts after test completion.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -28,7 +28,8 @@ def token(gov, Token):
 
 @pytest.fixture
 def vault(gov, guardian, management, token, rewards, Vault):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+    vault = guardian.deploy(Vault)
+    vault.initialize(token, gov, rewards, "", "", guardian)
     vault.setManagement(management, {"from": gov})
     # Make it so vault has some AUM to start
     token.approve(vault, token.balanceOf(gov) // 2, {"from": gov})

--- a/tests/functional/registry/conftest.py
+++ b/tests/functional/registry/conftest.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from brownie import compile_source
+from brownie import compile_source, Vault
 
 PACKAGE_VERSION = yaml.safe_load(
     (Path(__file__).parents[3] / "ethpm-config.yaml").read_text()
@@ -14,8 +14,11 @@ VAULT_SOURCE_CODE = (Path(__file__).parents[3] / "contracts/Vault.vy").read_text
 
 
 def patch_vault_version(version):
-    source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
-    return compile_source(source).Vyper
+    if version == PACKAGE_VERSION:
+        return Vault
+    else:
+        source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
+        return compile_source(source).Vyper
 
 
 @pytest.fixture

--- a/tests/functional/registry/conftest.py
+++ b/tests/functional/registry/conftest.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import difflib
+
+import pytest
+import yaml
+
+from brownie import compile_source
+
+PACKAGE_VERSION = yaml.safe_load(
+    (Path(__file__).parents[3] / "ethpm-config.yaml").read_text()
+)["version"]
+
+
+VAULT_SOURCE_CODE = (Path(__file__).parents[3] / "contracts/Vault.vy").read_text()
+
+
+def patch_vault_version(version):
+    source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
+    [print(li) for li in difflib.ndiff(VAULT_SOURCE_CODE, source) if li[0] != " "]
+    return compile_source(source).Vyper
+
+
+@pytest.fixture
+def create_token(gov, Token):
+    def create_token():
+        return Token.deploy({"from": gov})
+
+    yield create_token
+
+
+@pytest.fixture
+def create_vault(gov, create_token):
+    def create_vault(token=None, version=PACKAGE_VERSION):
+        if token is None:
+            token = create_token()
+        vault = patch_vault_version(version).deploy({"from": gov})
+        vault.initialize(
+            token, gov, gov, f"Yearn {token.name()} Vault", f"yv{token.symbol()}", gov
+        )
+        assert vault.token() == token
+        return vault
+
+    yield create_vault
+
+
+@pytest.fixture
+def registry(gov, Registry):
+    yield Registry.deploy({"from": gov})

--- a/tests/functional/registry/conftest.py
+++ b/tests/functional/registry/conftest.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import difflib
 
 import pytest
 import yaml
@@ -16,7 +15,6 @@ VAULT_SOURCE_CODE = (Path(__file__).parents[3] / "contracts/Vault.vy").read_text
 
 def patch_vault_version(version):
     source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
-    [print(li) for li in difflib.ndiff(VAULT_SOURCE_CODE, source) if li[0] != " "]
     return compile_source(source).Vyper
 
 

--- a/tests/functional/registry/conftest.py
+++ b/tests/functional/registry/conftest.py
@@ -1,24 +1,4 @@
-from pathlib import Path
-
 import pytest
-import yaml
-
-from brownie import compile_source, Vault
-
-PACKAGE_VERSION = yaml.safe_load(
-    (Path(__file__).parents[3] / "ethpm-config.yaml").read_text()
-)["version"]
-
-
-VAULT_SOURCE_CODE = (Path(__file__).parents[3] / "contracts/Vault.vy").read_text()
-
-
-def patch_vault_version(version):
-    if version == PACKAGE_VERSION:
-        return Vault
-    else:
-        source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
-        return compile_source(source).Vyper
 
 
 @pytest.fixture
@@ -30,8 +10,8 @@ def create_token(gov, Token):
 
 
 @pytest.fixture
-def create_vault(gov, create_token):
-    def create_vault(token=None, version=PACKAGE_VERSION):
+def create_vault(gov, create_token, patch_vault_version):
+    def create_vault(token=None, version=None):
         if token is None:
             token = create_token()
         vault = patch_vault_version(version).deploy({"from": gov})

--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -27,3 +27,31 @@ def test_registry_setGovernance(gov, registry, rando):
     # Only new governance can accept a change of governance
     with brownie.reverts():
         registry.acceptGovernance({"from": gov})
+
+
+def test_banksy(gov, registry, create_vault, rando):
+    vault = create_vault()
+    registry.newRelease(vault)
+    assert registry.tags(vault) == ""
+
+    # Not just anyone can tag a Vault, only a Banksy can!
+    with brownie.reverts():
+        registry.tagVault(vault, "Anything I want!", {"from": rando})
+
+    # Not just anyone can become a banksy either
+    with brownie.reverts():
+        registry.setBanksy(rando, {"from": rando})
+
+    assert not registry.banksy(rando)
+    registry.setBanksy(rando, {"from": gov})
+    assert registry.banksy(rando)
+
+    registry.tagVault(vault, "Anything I want!", {"from": rando})
+    assert registry.tags(vault) == "Anything I want!"
+
+    registry.setBanksy(rando, False, {"from": gov})
+    with brownie.reverts():
+        registry.tagVault(vault, "", {"from": rando})
+
+    assert not registry.banksy(gov)
+    registry.tagVault(vault, "", {"from": gov})

--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -1,0 +1,29 @@
+import pytest
+import brownie
+
+
+def test_registry_deployment(gov, registry):
+    assert registry.governance() == gov
+    assert registry.nextRelease() == 0
+
+
+def test_registry_setGovernance(gov, registry, rando):
+    newGov = rando
+    # No one can set governance but governance
+    with brownie.reverts():
+        registry.setGovernance(newGov, {"from": newGov})
+    # Governance doesn't change until it's accepted
+    registry.setGovernance(newGov, {"from": gov})
+    assert registry.governance() == gov
+    # Only new governance can accept a change of governance
+    with brownie.reverts():
+        registry.acceptGovernance({"from": gov})
+    # Governance doesn't change until it's accepted
+    registry.acceptGovernance({"from": newGov})
+    assert registry.governance() == newGov
+    # No one can set governance but governance
+    with brownie.reverts():
+        registry.setGovernance(newGov, {"from": gov})
+    # Only new governance can accept a change of governance
+    with brownie.reverts():
+        registry.acceptGovernance({"from": gov})

--- a/tests/functional/registry/test_deployment.py
+++ b/tests/functional/registry/test_deployment.py
@@ -1,0 +1,36 @@
+import brownie
+
+
+def test_deployment_management(
+    gov, guardian, rewards, registry, Vault, create_token, create_vault
+):
+    token = create_token()
+
+    # No deployments yet for token
+    with brownie.reverts():
+        registry.latestVault(token)
+
+    # Creating the first deployment makes `latestVault()` work
+    v1_vault = create_vault(token, version="1.0.0")
+    registry.newRelease(v1_vault, {"from": gov})
+    assert registry.latestVault(token) == v1_vault
+    assert registry.latestRelease() == v1_vault.apiVersion() == "1.0.0"
+
+    # Can't deploy the same vault api version twice, proxy or not
+    with brownie.reverts():
+        registry.newVault(token, guardian, rewards, "", "", {"from": gov})
+
+    # New release overrides previous release
+    v2_vault = create_vault(version="2.0.0")  # Uses different token
+    registry.newRelease(v2_vault, {"from": gov})
+    assert registry.latestVault(token) == v1_vault
+    assert registry.latestRelease() == v2_vault.apiVersion() == "2.0.0"
+
+    # You can deploy proxy Vaults, linked to the latest release
+    proxy_vault = Vault.at(
+        registry.newVault(token, guardian, rewards, "", "", {"from": gov}).return_value
+    )
+    assert proxy_vault.apiVersion() == v2_vault.apiVersion() == "2.0.0"
+    assert proxy_vault.rewards() == rewards
+    assert proxy_vault.guardian() == guardian
+    assert registry.latestVault(token) == proxy_vault

--- a/tests/functional/registry/test_release.py
+++ b/tests/functional/registry/test_release.py
@@ -1,0 +1,21 @@
+import brownie
+
+
+def test_release_management(gov, registry, create_vault):
+    # No releases yet
+    with brownie.reverts():
+        registry.latestRelease()
+
+    # Creating the first release makes `latestRelease()` work
+    v1_vault = create_vault(version="1.0.0")
+    registry.newRelease(v1_vault, {"from": gov})
+    assert registry.latestRelease() == v1_vault.apiVersion() == "1.0.0"
+
+    # Can't release same vault twice (cannot have the same api version)
+    with brownie.reverts():
+        registry.newRelease(v1_vault, {"from": gov})
+
+    # New release overrides previous release
+    v2_vault = create_vault(version="2.0.0")
+    registry.newRelease(v2_vault, {"from": gov})
+    assert registry.latestRelease() == v2_vault.apiVersion() == "2.0.0"

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -39,7 +39,10 @@ def test_good_migration(
 def test_bad_migration(
     token, vault, strategy, gov, strategist, TestStrategy, Vault, rando
 ):
-    different_vault = gov.deploy(Vault, token, gov, gov, "", "")
+    different_vault = gov.deploy(Vault)
+    different_vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
     new_strategy = strategist.deploy(TestStrategy, different_vault)
 
     # Can't migrate to a strategy with a different vault

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -14,7 +14,10 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 def test_vault_deployment(guardian, gov, rewards, token, Vault):
     # Deploy the Vault without any name/symbol overrides
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+    vault = guardian.deploy(Vault)
+    vault.initialize(
+        token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
+    )
     # Addresses
     assert vault.governance() == gov
     assert vault.management() == gov
@@ -38,7 +41,8 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
 
 def test_vault_name_symbol_override(guardian, gov, rewards, token, Vault):
     # Deploy the Vault with name/symbol overrides
-    vault = guardian.deploy(Vault, token, gov, rewards, "crvY yVault", "yvcrvY")
+    vault = guardian.deploy(Vault)
+    vault.initialize(token, gov, rewards, "crvY yVault", "yvcrvY", guardian)
     # Assert that the overrides worked
     assert vault.name() == "crvY yVault"
     assert vault.symbol() == "yvcrvY"

--- a/tests/functional/vault/test_losses.py
+++ b/tests/functional/vault/test_losses.py
@@ -7,7 +7,11 @@ DAY = 86400  # seconds
 @pytest.fixture
 def vault(gov, token, Vault):
     # NOTE: Because the fixture has tokens in it already
-    yield gov.deploy(Vault, token, gov, gov, "", "")
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
+    yield vault
 
 
 @pytest.fixture

--- a/tests/functional/vault/test_misc.py
+++ b/tests/functional/vault/test_misc.py
@@ -8,7 +8,10 @@ def other_token(gov, Token):
 
 
 def test_regular_available_deposit_limit(Vault, token, gov):
-    vault = gov.deploy(Vault, token, gov, gov, "", "")
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
     token.approve(vault, 100, {"from": gov})
     vault.setDepositLimit(100)
 
@@ -20,7 +23,10 @@ def test_regular_available_deposit_limit(Vault, token, gov):
 
 
 def test_negative_available_deposit_limit(Vault, token, gov):
-    vault = gov.deploy(Vault, token, gov, gov, "", "")
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
     token.approve(vault, 100, {"from": gov})
     vault.setDepositLimit(100)
 

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -5,7 +5,11 @@ import brownie
 @pytest.fixture
 def vault(gov, token, Vault):
     # NOTE: Overriding the one in conftest because it has values already
-    yield gov.deploy(Vault, token, gov, gov, "", "")
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
+    yield vault
 
 
 @pytest.fixture

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -8,7 +8,11 @@ ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
 @pytest.fixture
 def vault(gov, token, Vault):
     # NOTE: Because the fixture has tokens in it already
-    yield gov.deploy(Vault, token, gov, gov, "", "")
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
+    yield vault
 
 
 @pytest.fixture
@@ -26,7 +30,15 @@ def other_strategy(gov, vault, TestStrategy):
 @pytest.fixture
 def wrong_strategy(gov, Vault, Token, TestStrategy):
     otherToken = gov.deploy(Token)
-    otherVault = gov.deploy(Vault, otherToken, gov, gov, "", "")
+    otherVault = gov.deploy(Vault)
+    otherVault.initialize(
+        otherToken,
+        gov,
+        gov,
+        otherToken.symbol() + " yVault",
+        "yv" + otherToken.symbol(),
+        gov,
+    )
     yield gov.deploy(TestStrategy, otherVault)
 
 

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -3,7 +3,16 @@ import brownie
 
 def test_multiple_withdrawals(chain, token, gov, Vault, TestStrategy):
     # Need a fresh vault to do this math right
-    vault = Vault.deploy(token, gov, gov, "", "", {"from": gov})
+    vault = Vault.deploy({"from": gov})
+    vault.initialize(
+        token,
+        gov,
+        gov,
+        token.symbol() + " yVault",
+        "yv" + token.symbol(),
+        gov,
+        {"from": gov},
+    )
     starting_balance = token.balanceOf(gov)
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
     [
@@ -89,7 +98,10 @@ def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
 def test_progressive_withdrawal(
     chain, token, gov, Vault, guardian, rewards, TestStrategy
 ):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+    vault = guardian.deploy(Vault)
+    vault.initialize(
+        token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
+    )
 
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(2)]
     [vault.addStrategy(s, 1000, 10, 1000, {"from": gov}) for s in strategies]
@@ -140,7 +152,10 @@ def test_progressive_withdrawal(
 def test_withdrawal_with_empty_queue(
     chain, token, gov, Vault, guardian, rewards, TestStrategy
 ):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+    vault = guardian.deploy(Vault)
+    vault.initialize(
+        token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
+    )
 
     strategy = gov.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 1000, 10, 1000, {"from": gov})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,7 +31,10 @@ def guardian(accounts):
 
 @pytest.fixture
 def vault(gov, rewards, guardian, token, Vault):
-    vault = guardian.deploy(Vault, token, gov, rewards, "", "")
+    vault = guardian.deploy(Vault)
+    vault.initialize(
+        token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
+    )
     yield vault
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,24 +1,4 @@
-from pathlib import Path
-
 import pytest
-import yaml
-
-from brownie import compile_source, Vault
-
-PACKAGE_VERSION = yaml.safe_load(
-    (Path(__file__).parents[2] / "ethpm-config.yaml").read_text()
-)["version"]
-
-
-VAULT_SOURCE_CODE = (Path(__file__).parents[2] / "contracts/Vault.vy").read_text()
-
-
-def patch_vault_version(version):
-    if version == PACKAGE_VERSION:
-        return Vault
-    else:
-        source = VAULT_SOURCE_CODE.replace(PACKAGE_VERSION, version)
-        return compile_source(source).Vyper
 
 
 @pytest.fixture
@@ -60,8 +40,8 @@ def guardian(accounts):
 
 
 @pytest.fixture
-def create_vault(gov, rewards, guardian, create_token):
-    def create_vault(token=None, version=PACKAGE_VERSION):
+def create_vault(gov, rewards, guardian, create_token, patch_vault_version):
+    def create_vault(token=None, version=None):
         if token is None:
             token = create_token()
         vault = patch_vault_version(version).deploy({"from": guardian})

--- a/tests/integration/test_release.py
+++ b/tests/integration/test_release.py
@@ -1,0 +1,119 @@
+from semantic_version import Version
+
+from brownie.test import strategy
+
+from brownie import Vault
+
+
+class ReleaseTest:
+
+    st_bool = strategy("bool")
+
+    def __init__(self, gov, registry, create_token, create_vault):
+        self.gov = gov
+        self.registry = registry
+        self.create_token = lambda s: create_token()
+
+        def create_vault_adaptor(self, *args, **kwargs):
+            return create_vault(*args, **kwargs)
+
+        self.create_vault = create_vault_adaptor
+
+    def setup(self):
+        self.latest_version = Version("1.0.0")
+        token = self.create_token()
+        vault = self.create_vault(token, version=str(self.latest_version))
+        self.vaults = {token: [vault]}
+        self.registry.newRelease(vault, {"from": self.gov})
+        self.experiments = {}
+
+    def rule_new_release(self, new_token="st_bool"):
+        if new_token or len(self.vaults.keys()) == 0:
+            token = self.create_token()
+        else:
+            token = list(self.vaults.keys())[-1]
+
+        self.latest_version = self.latest_version.next_patch()
+
+        vault = self.create_vault(token, version=str(self.latest_version))
+        print(f"Registry.newRelease({token}, {self.latest_version})")
+        self.registry.newRelease(vault, {"from": self.gov})
+
+        if token in self.vaults:
+            self.vaults[token].append(vault)
+        else:
+            self.vaults[token] = [vault]
+
+    def rule_new_deployment(self, new_token="st_bool"):
+        tokens_with_stale_deployments = [
+            token
+            for token, deployments in self.vaults.items()
+            if Version(deployments[-1].apiVersion()) < self.latest_version
+        ]
+        if new_token or len(tokens_with_stale_deployments) == 0:
+            token = self.create_token()
+        else:
+            token = tokens_with_stale_deployments[-1]
+
+        print(f"Registry.newVault({token}, {self.latest_version})")
+        vault = Vault.at(
+            self.registry.newVault(token, self.gov, self.gov, "", "").return_value
+        )
+
+        if token in self.vaults:
+            self.vaults[token].append(vault)
+        else:
+            self.vaults[token] = [vault]
+
+    def rule_new_experiment(self):
+        token = self.create_token()
+        print(f"Registry.newExperimentalVault({token}, {self.latest_version})")
+
+        vault = Vault.at(
+            self.registry.newExperimentalVault(
+                token, self.gov, self.gov, self.gov, "", ""
+            ).return_value
+        )
+
+        self.experiments[token] = [vault]
+
+    def rule_endorse_experiment(self):
+        experiments_with_latest_api = [
+            (token, deployments[-1])
+            for token, deployments in self.experiments.items()
+            if (
+                Version(deployments[-1].apiVersion()) == self.latest_version
+                and (
+                    token not in self.vaults
+                    or Version(self.vaults[token][-1].apiVersion())
+                    < Version(deployments[-1].apiVersion())
+                )
+            )
+        ]
+        if len(experiments_with_latest_api) > 0:
+            token, vault = experiments_with_latest_api[-1]
+            print(f"Registry.endorseVault({token}, {self.latest_version})")
+            self.registry.endorseVault(vault, {"from": self.gov})
+
+            if token in self.vaults:
+                self.vaults[token].append(vault)
+            else:
+                self.vaults[token] = [vault]
+
+    def invariant(self):
+        for token, deployments in self.vaults.items():
+            # Check that token matches up
+            assert deployments[0].token() == token
+            # Strictly linearly increasing versions
+            last_version = Version(deployments[0].apiVersion())
+            assert last_version <= self.latest_version
+
+            for vault in deployments[1:]:
+                # Check that token matches up
+                assert vault.token() == token
+                # Strictly linearly increasing versions
+                assert last_version < Version(vault.apiVersion()) <= self.latest_version
+
+
+def test_releases(gov, registry, create_token, create_vault, state_machine):
+    state_machine(ReleaseTest, gov, registry, create_token, create_vault)

--- a/tests/integration/test_release.py
+++ b/tests/integration/test_release.py
@@ -116,4 +116,12 @@ class ReleaseTest:
 
 
 def test_releases(gov, registry, create_token, create_vault, state_machine):
-    state_machine(ReleaseTest, gov, registry, create_token, create_vault)
+    state_machine(
+        ReleaseTest,
+        gov,
+        registry,
+        create_token,
+        create_vault,
+        # NOTE: Taking too long with default settings
+        settings={"max_examples": 20, "stateful_step_count": 6},
+    )


### PR DESCRIPTION
fixes: #45 
fixes: #47 

This PR takes the concept of the "Vault Registry" and simplifies it down to the bare bones: managing an ordered list of Vault releases and deployments. From these lists, it will be possible to further specialize around this, towards the final goal of making it possible to get a snapshot of the entire Yearn Vault ecosystem from one contract address.

There are two specializations for Vaults:
1. "Experimental" or community-deployed Vaults (unendorsed by Yearn)
2. "Endorsed" vaults, explicitly managed by Yearn, and considered a part of the Yearn ecosystem

TODO:
- [x] vault deprecation story
- [x] more testing (possibly event testing as well)
- [x] fuzzing test with multiple releases/deployments
- [x] Add docstrings
- [x] update Specification
- [x] add Vault release and deployment management to Vault deployment script