### PR TITLE
feat: standard permit

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -147,7 +147,7 @@ SECS_PER_YEAR: constant(uint256) = 31_557_600  # 365.25 days
 nonces: public(HashMap[address, uint256])
 DOMAIN_SEPARATOR: public(bytes32)
 DOMAIN_TYPE_HASH: constant(bytes32) = keccak256('EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)')
-PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 amount,uint256 nonce,uint256 expiry)")
+PERMIT_TYPE_HASH: constant(bytes32) = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")
 
 
 @external

--- a/tests/functional/vault/test_permit.py
+++ b/tests/functional/vault/test_permit.py
@@ -9,7 +9,7 @@ owner = Account.create()
 spender = Account.create()
 
 
-def generate_permit(vault, owner: Account, spender: Account, amount, nonce, expiry):
+def generate_permit(vault, owner: Account, spender: Account, value, nonce, deadline):
     name = "Yearn Vault"
     version = vault.apiVersion()
     chain_id = 1  # ganache bug https://github.com/trufflesuite/ganache/issues/1643
@@ -25,9 +25,9 @@ def generate_permit(vault, owner: Account, spender: Account, amount, nonce, expi
             "Permit": [
                 {"name": "owner", "type": "address"},
                 {"name": "spender", "type": "address"},
-                {"name": "amount", "type": "uint256"},
+                {"name": "value", "type": "uint256"},
                 {"name": "nonce", "type": "uint256"},
-                {"name": "expiry", "type": "uint256"},
+                {"name": "deadline", "type": "uint256"},
             ],
         },
         "domain": {
@@ -40,9 +40,9 @@ def generate_permit(vault, owner: Account, spender: Account, amount, nonce, expi
         "message": {
             "owner": owner.address,
             "spender": spender.address,
-            "amount": amount,
+            "value": value,
             "nonce": nonce,
-            "expiry": expiry,
+            "deadline": deadline,
         },
     }
     return encode_structured_data(data)


### PR DESCRIPTION
Change permit type hash to the one defined by [EIP-2612](https://eips.ethereum.org/EIPS/eip-2612).

This will allow to use off-the-shelf examples for Permit messages:
```
{
        "types": {
            "EIP712Domain": [
                {"name": "name", "type": "string"},
                {"name": "version", "type": "string"},
                {"name": "chainId", "type": "uint256"},
                {"name": "verifyingContract", "type": "address"},
            ],
            "Permit": [
                {"name": "owner", "type": "address"},
                {"name": "spender", "type": "address"},
                {"name": "value", "type": "uint256"},
                {"name": "nonce", "type": "uint256"},
                {"name": "deadline", "type": "uint256"},
            ],
        },
        "domain": {
            "name": "Yearn Vault",
            "version": vault.apiVersion(),
            "chainId": 1,
            "verifyingContract": str(vault),
        },
        "primaryType": "Permit",
        "message": {
            "owner": owner,
            "spender": spender,
            "value": value,
            "nonce": vault.nonces(owner),
            "deadline": deadline,
        },
    }
```