### PR TITLE
fix: check for strategy vault and want address matches on add

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -50,6 +50,8 @@ interface DetailedERC20:
 
 
 interface Strategy:
+    def want() -> address: view
+    def vault() -> address: view
     def estimatedTotalAssets() -> uint256: view
     def withdraw(_amount: uint256): nonpayable
     def migrate(_newStrategy: address): nonpayable
@@ -946,6 +948,8 @@ def addStrategy(
 
     assert msg.sender == self.governance
     assert self.strategies[_strategy].activation == 0
+    assert self == Strategy(_strategy).vault() 
+    assert self.token.address == Strategy(_strategy).want() 
     self.strategies[_strategy] = StrategyParams({
         performanceFee: _performanceFee,
         activation: block.timestamp,

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -17,7 +17,14 @@ def strategy(gov, vault, TestStrategy):
     yield gov.deploy(TestStrategy, vault)
 
 
-def test_addStrategy(chain, gov, vault, strategy, rando):
+@pytest.fixture
+def wrong_strategy(gov, Vault, Token, TestStrategy):
+    otherToken = gov.deploy(Token)
+    otherVault = gov.deploy(Vault, otherToken, gov, gov, "", "")
+    yield gov.deploy(TestStrategy, otherVault)
+
+
+def test_addStrategy(chain, gov, vault, strategy, wrong_strategy, rando):
 
     # Only governance can add a strategy
     with brownie.reverts():
@@ -51,6 +58,10 @@ def test_addStrategy(chain, gov, vault, strategy, rando):
     # Can't add a strategy twice
     with brownie.reverts():
         vault.addStrategy(strategy, 10000, 10, 1000, {"from": gov})
+
+    # Can't add a strategy with incorrect vault or want token
+    with brownie.reverts():
+        vault.addStrategy(wrong_strategy, 10000, 10, 1000, {"from": gov})
 
 
 def test_updateStrategy(chain, gov, vault, strategy, rando):


### PR DESCRIPTION
Change Log:
* adds assertions for checking want and vault address when adding a strategy
* updates unit test

