### PR TITLE
feat: use debt ratio vs. absolute debt limit

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -8,7 +8,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 struct StrategyParams {
     uint256 performanceFee;
     uint256 activation;
-    uint256 debtLimit;
+    uint256 debtRatio;
     uint256 rateLimit;
     uint256 lastReport;
     uint256 totalDebt;
@@ -384,7 +384,7 @@ abstract contract BaseStrategy {
      * @return True if the strategy is actively managing a position.
      */
     function isActive() public view returns (bool) {
-        return vault.strategies(address(this)).debtLimit > 0 || estimatedTotalAssets() > 0;
+        return vault.strategies(address(this)).debtRatio > 0 || estimatedTotalAssets() > 0;
     }
 
     /**

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -538,11 +538,12 @@ abstract contract BaseStrategy {
         if (block.timestamp.sub(params.lastReport) >= minReportDelay) return true;
 
         // If some amount is owed, pay it back
-        // NOTE: Since debt is adjusted in step-wise fashion, it is appropriate
-        //       to always trigger here, because the resulting change should be
-        //       large (might not always be the case).
+        // NOTE: Since debt is based on deposits, it makes sense to guard against large
+        //       changes to the value from triggering a harvest directly through user
+        //       behavior. This should ensure reasonable resistance to manipulation
+        //       from user-initiated withdrawals as the outstanding debt fluctuates.
         uint256 outstanding = vault.debtOutstanding();
-        if (outstanding > 0) return true;
+        if (outstanding > debtThreshold) return true;
 
         // Check for profits and losses
         uint256 total = estimatedTotalAssets();

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1178,6 +1178,8 @@ def migrateStrategy(oldVersion: address, newVersion: address):
     self._revokeStrategy(oldVersion)
     # _revokeStrategy will lower the debtRatio
     self.debtRatio += strategy.debtRatio
+    # Debt is migrated to new strategy
+    self.strategies[oldVersion].totalDebt = 0
 
     self.strategies[newVersion] = StrategyParams({
         performanceFee: strategy.performanceFee,

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -56,8 +56,8 @@ def strategy(gov, strategist, keeper, token, vault, TestStrategy):
     strategy.setKeeper(keeper, {"from": strategist})
     vault.addStrategy(
         strategy,
-        token.totalSupply() // 5,  # Debt limit of 20% of token supply (40% of Vault)
-        token.totalSupply() // 8640000,  # Rate limit of 1% of token supply per day
+        4_000,  # 40% of Vault
+        vault.totalAssets() // 8640000,  # Rate limit of 1% of vault's assets per day
         1000,  # 10% performance fee for Strategist
         {"from": gov},
     )

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -10,7 +10,7 @@ def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     assert vault.balanceOf(strategist) == 0
 
     strategy = strategist.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 10 ** 18, 1000, 50, {"from": gov})
+    vault.addStrategy(strategy, 2_000, 1000, 50, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
     strategy.harvest({"from": strategist})
 
@@ -26,7 +26,7 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     assert vault.balanceOf(strategist) == 0
 
     strategy = strategist.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 10 ** 18, 1000, 0, {"from": gov})
+    vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
     strategy.harvest({"from": strategist})
 

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -23,7 +23,7 @@ def test_harvest_tend_trigger(chain, gov, vault, token, TestStrategy):
     # Trigger doesn't work until strategy is added
     assert not strategy.harvestTrigger(0)
 
-    vault.addStrategy(strategy, 10 ** 18, 2 ** 256 - 1, 50, {"from": gov})
+    vault.addStrategy(strategy, 2_000, 2 ** 256 - 1, 50, {"from": gov})
 
     # Check that trigger works when it goes over time
     assert not strategy.harvestTrigger(0)

--- a/tests/functional/strategy/test_rate_limit.py
+++ b/tests/functional/strategy/test_rate_limit.py
@@ -4,10 +4,8 @@ import brownie
 
 def test_simple_limit(chain, gov, vault, token, TestStrategy):
     strategy = gov.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 1000, 10, 0, {"from": gov})
-
-    token.approve(vault, 5000, {"from": gov})
-    vault.deposit(5000, {"from": gov})
+    # NOTE: 20 % of Vault assets is 2_000 BPS
+    vault.addStrategy(strategy, 2_000, 10, 0, {"from": gov})
 
     # Mine a block in a second
     start = chain.time()
@@ -17,23 +15,25 @@ def test_simple_limit(chain, gov, vault, token, TestStrategy):
     strategy.harvest({"from": gov})
     # Doing this because even if set the time of the block
     # the clock keeps ticking while the code runs.
-    # a balance of 40 would mean that it took more than 4 secs
+    # a balance of 20 would mean that it took more than 2 secs
     # to harvest
-    assert token.balanceOf(strategy) <= 40
+    assert token.balanceOf(strategy) < 20
 
     # After a while the strategy will be able to get up to debtLimit
     chain.mine(1, start + 1000)
     strategy.harvest({"from": gov})
-    assert token.balanceOf(strategy) == 1000
+    # Doing this because even if set the time of the block
+    # the clock keeps ticking while the code runs.
+    # a balance of 10020 would mean that it took more than 2 secs
+    # to harvest
+    assert token.balanceOf(strategy) < 10020
 
 
-def test_zero_limit(chain, gov, vault, token, TestStrategy):
+def test_zero_limit(gov, vault, token, TestStrategy):
     strategy = gov.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 1000, 0, 0, {"from": gov})
-
-    token.approve(vault, 5000, {"from": gov})
-    vault.deposit(5000, {"from": gov})
+    # NOTE: 20 % of Vault assets is 2_000 BPS
+    vault.addStrategy(strategy, 2_000, 0, 0, {"from": gov})
 
     assert token.balanceOf(strategy) == 0
     strategy.harvest({"from": gov})
-    assert token.balanceOf(strategy) == 1000
+    assert token.balanceOf(strategy) == vault.totalAssets() // 5

--- a/tests/functional/strategy/test_rate_limit.py
+++ b/tests/functional/strategy/test_rate_limit.py
@@ -8,25 +8,24 @@ def test_simple_limit(chain, gov, vault, token, TestStrategy):
     vault.addStrategy(strategy, 2_000, 10, 0, {"from": gov})
 
     # Mine a block in a second
-    start = chain.time()
-    chain.mine(1, start + 1)
+    chain.mine(timedelta=1)
 
     assert token.balanceOf(strategy) == 0
     strategy.harvest({"from": gov})
     # Doing this because even if set the time of the block
     # the clock keeps ticking while the code runs.
-    # a balance of 20 would mean that it took more than 2 secs
-    # to harvest
-    assert token.balanceOf(strategy) < 20
+    # a balance of 30 would mean that it took more than 1 secs
+    # to harvest (+1 for the timedelta, and potentially +1 for rollover)
+    assert token.balanceOf(strategy) < 30
 
     # After a while the strategy will be able to get up to debtLimit
-    chain.mine(1, start + 1000)
+    chain.mine(timedelta=1000)
     strategy.harvest({"from": gov})
     # Doing this because even if set the time of the block
     # the clock keeps ticking while the code runs.
-    # a balance of 10020 would mean that it took more than 2 secs
-    # to harvest
-    assert token.balanceOf(strategy) < 10020
+    # a balance of 10030 would mean that it took more than 1 secs
+    # to harvest (+1 for the timedelta, and potentially +1 for rollover)
+    assert token.balanceOf(strategy) < 10030
 
 
 def test_zero_limit(gov, vault, token, TestStrategy):

--- a/tests/functional/strategy/test_startup.py
+++ b/tests/functional/strategy/test_startup.py
@@ -75,8 +75,10 @@ def test_startup(token, gov, vault, strategy, keeper, chain):
 
     # Ramp up debt (Should execute at least once)
     debt_limit_hit = lambda: (
-        vault.strategies(strategy).dict()["totalDebt"]
-        == vault.strategies(strategy).dict()["debtLimit"]
+        vault.strategies(strategy).dict()["totalDebt"] / vault.totalAssets()
+        # NOTE: Needs to hit at least 99% of the debt ratio, because 100% is unobtainable
+        #       (Strategy increases it's absolute debt every harvest)
+        >= 0.99 * vault.strategies(strategy).dict()["debtRatio"] / 10_000
     )
     assert not debt_limit_hit()
     while not debt_limit_hit():

--- a/tests/functional/strategy/test_withdrawal.py
+++ b/tests/functional/strategy/test_withdrawal.py
@@ -10,7 +10,8 @@ def test_withdraw(chain, gov, token, vault, strategy, rando):
 
     balance = strategy.estimatedTotalAssets()
     strategy.withdraw(balance // 2, {"from": vault.address})
-    assert strategy.estimatedTotalAssets() == balance // 2
+    # NOTE: This may be +1 more than just dividing it
+    assert strategy.estimatedTotalAssets() == balance - balance // 2
 
     # Not just anyone can call it
     with brownie.reverts():

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -30,7 +30,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.decimals() == token.decimals()
     assert vault.apiVersion() == PACKAGE_VERSION
 
-    assert vault.debtLimit() == 0
+    assert vault.debtRatio() == 0
     assert vault.depositLimit() == 0
     assert vault.creditAvailable() == 0
     assert vault.debtOutstanding() == 0
@@ -93,7 +93,7 @@ def test_vault_setParams(
 @pytest.mark.parametrize(
     "key,setter,val",
     [
-        ("debtLimit", "updateStrategyDebtLimit", 500),
+        ("debtRatio", "updateStrategyDebtRatio", 500),
         ("rateLimit", "updateStrategyRateLimit", 10),
     ],
 )

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -91,14 +91,14 @@ def test_vault_setParams(
 
 
 @pytest.mark.parametrize(
-    "key,setter,val",
+    "key,setter,val,max",
     [
-        ("debtRatio", "updateStrategyDebtRatio", 500),
-        ("rateLimit", "updateStrategyRateLimit", 10),
+        ("debtRatio", "updateStrategyDebtRatio", 500, 10000),
+        ("rateLimit", "updateStrategyRateLimit", 10, None),
     ],
 )
 def test_vault_updateStrategy(
-    chain, gov, guardian, management, vault, strategy, rando, key, setter, val
+    chain, gov, guardian, management, vault, strategy, rando, key, setter, val, max
 ):
 
     # rando shouldn't be able to call these methods
@@ -112,11 +112,21 @@ def test_vault_updateStrategy(
     # management is always allowed
     getattr(vault, setter)(strategy, val, {"from": management})
     assert vault.strategies(strategy).dict()[key] == val
-    chain.undo()
+
+    chain.undo()  # Revert previous setting
+    assert vault.strategies(strategy).dict()[key] != val
 
     # gov is always allowed
     getattr(vault, setter)(strategy, val, {"from": gov})
     assert vault.strategies(strategy).dict()[key] == val
+
+    if max:
+        # Can't set it more than max
+        getattr(vault, setter)(strategy, max, {"from": gov})
+        assert vault.strategies(strategy).dict()[key] == max
+        with brownie.reverts():
+            getattr(vault, setter)(strategy, max + 1, {"from": gov})
+        assert vault.strategies(strategy).dict()[key] == max
 
 
 def test_vault_setGovernance(gov, vault, rando):

--- a/tests/functional/vault/test_losses.py
+++ b/tests/functional/vault/test_losses.py
@@ -23,8 +23,8 @@ def strategy(gov, vault, TestStrategy):
 
 def test_losses(chain, vault, strategy, gov, token):
     vault.addStrategy(strategy, 1000, 1000, 0, {"from": gov})
-    token.approve(vault, 500, {"from": gov})
-    vault.deposit(500, {"from": gov})
+    token.approve(vault, 2 ** 256 - 1, {"from": gov})
+    vault.deposit(5000, {"from": gov})
 
     chain.sleep(DAY // 10)
     strategy.harvest({"from": gov})
@@ -33,6 +33,7 @@ def test_losses(chain, vault, strategy, gov, token):
     # First loss
     chain.sleep(DAY // 10)
     strategy._takeFunds(100, {"from": gov})
+    vault.deposit(100, {"from": gov})  # NOTE: total assets doesn't change
     strategy.harvest({"from": gov})
     params = vault.strategies(strategy).dict()
     assert params["totalLoss"] == 100
@@ -41,6 +42,7 @@ def test_losses(chain, vault, strategy, gov, token):
     # Harder second loss
     chain.sleep(DAY // 10)
     strategy._takeFunds(300, {"from": gov})
+    vault.deposit(300, {"from": gov})  # NOTE: total assets doesn't change
     strategy.harvest({"from": gov})
     params = vault.strategies(strategy).dict()
     assert params["totalLoss"] == 400
@@ -50,6 +52,7 @@ def test_losses(chain, vault, strategy, gov, token):
     chain.sleep(DAY // 10)
     assert token.balanceOf(strategy) == 100
     strategy._takeFunds(100, {"from": gov})
+    vault.deposit(100, {"from": gov})  # NOTE: total assets doesn't change
     assert token.balanceOf(strategy) == 0
     strategy.harvest({"from": gov})
     params = vault.strategies(strategy).dict()

--- a/tests/functional/vault/test_misc.py
+++ b/tests/functional/vault/test_misc.py
@@ -95,7 +95,7 @@ def test_reject_ether(gov, vault):
         ("addStrategy", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1, 1, 1]),
         ("addStrategyToQueue", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
         ("removeStrategyFromQueue", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]),
-        ("updateStrategyDebtLimit", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1]),
+        ("updateStrategyDebtRatio", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1]),
         ("updateStrategyRateLimit", ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2", 1]),
         (
             "updateStrategyPerformanceFee",

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -44,7 +44,9 @@ def wrong_strategy(gov, Vault, Token, TestStrategy):
     yield gov.deploy(TestStrategy, otherVault)
 
 
-def test_addStrategy(chain, gov, vault, strategy, wrong_strategy, rando):
+def test_addStrategy(
+    chain, gov, vault, strategy, other_strategy, wrong_strategy, rando
+):
 
     # Only governance can add a strategy
     with brownie.reverts():
@@ -82,6 +84,14 @@ def test_addStrategy(chain, gov, vault, strategy, wrong_strategy, rando):
     # Can't add a strategy with incorrect vault or want token
     with brownie.reverts():
         vault.addStrategy(wrong_strategy, 100, 10, 1000, {"from": gov})
+
+    # Can't add a strategy with a debt ratio more than the maximum
+    leftover_ratio = 10_000 - vault.debtRatio()
+    with brownie.reverts():
+        vault.addStrategy(other_strategy, leftover_ratio + 1, 10, 1000, {"from": gov})
+
+    vault.addStrategy(other_strategy, leftover_ratio, 10, 1000, {"from": gov})
+    assert vault.debtRatio() == 10_000
 
 
 def test_updateStrategy(chain, gov, vault, strategy, rando):

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -19,7 +19,7 @@ def test_multiple_withdrawals(chain, token, gov, Vault, TestStrategy):
     [
         vault.addStrategy(
             s,
-            token.balanceOf(gov) // 10,  # 10% of all tokens
+            1_000,  # 10% of all tokens in Vault
             2 ** 256 - 1,  # No rate limit
             0,  # No fee
             {"from": gov},
@@ -70,7 +70,7 @@ def test_multiple_withdrawals(chain, token, gov, Vault, TestStrategy):
 def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
     # Add strategies
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
-    [vault.addStrategy(s, 1000, 10, 1000, {"from": gov}) for s in strategies]
+    [vault.addStrategy(s, 1000, 10 ** 15, 1000, {"from": gov}) for s in strategies]
 
     # Send tokens to random user
     token.approve(gov, 2 ** 256 - 1, {"from": gov})
@@ -89,7 +89,7 @@ def test_forced_withdrawal(token, gov, vault, TestStrategy, rando, chain):
 
     # Withdrawal should fail, no matter the distribution of tokens between
     # the vault and the strategies
-    while vault.totalDebt() < vault.debtLimit():
+    while vault.totalDebt() / vault.totalAssets() < vault.debtRatio() / 10_000:
         chain.sleep(86400)  # wait a day
         [s.harvest({"from": gov}) for s in strategies]
         with brownie.reverts():

--- a/tests/integration/test_operation.py
+++ b/tests/integration/test_operation.py
@@ -42,8 +42,8 @@ def test_normal_operation(
 ):
     vault.addStrategy(
         strategy,
-        token.balanceOf(vault),  # Go up to 100% of Vault AUM
-        token.balanceOf(vault),  # 100% of Vault AUM per block (no rate limit)
+        10_000,  # 100% of Vault AUM
+        2 ** 256 - 1,  # no rate limit
         1000,  # 10% performance fee for Strategist
         {"from": gov},
     )


### PR DESCRIPTION
fixes: #139

This PR transitions the Strategy debt limit from an absolute value to a ratio of the total assets of the Vault. This change introduces some dynamic behavior to the Vault, as this value is based on user deposits. This has the additional benefit of scaling up as the Vault's deposits fluctuate so governance/management does not have to manage these values as often.

This introduction should be safe as the use of `Vault.totalAssets()` to determine the absolute amount at the time of `Vault.report()` (from `Strategy.harvest()`) has the same safety conditions as `Vault.deposit()`/`Vault.withdraw()`. Additionally, `Strategy.harvestTrigger()` takes into account `Vault.creditAvailable(strategy)`, so integrations may need to watch for additional behavioral changes as this may make it more difficult to have the trigger evaluate true because of on-chain conditions that might affect it.

NOTE: The ratio is scaled to basis points. The maximum all of the connected strategies can have of the total assets in the Vault is 100%, although in practice ~90% is more advisible limit.