### PR TITLE
feat: protect against excessive losses

### DIFF
--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -72,11 +72,17 @@ contract TestStrategy is BaseStrategy {
             VaultAPI(address(vault)).withdraw(stratBalance, address(this));
         }
 
+        uint256 totalDebt = vault.strategies(address(this)).totalDebt;
         uint256 totalAssets = want.balanceOf(address(this));
         if (_amountNeeded > totalAssets) {
             _liquidatedAmount = totalAssets;
             _loss = _amountNeeded.sub(totalAssets);
         } else {
+            // NOTE: Just in case something was stolen from this contract
+            if (totalDebt > totalAssets) {
+                _loss = totalDebt.sub(totalAssets);
+                if (_loss > _amountNeeded) _loss = _amountNeeded;
+            }
             _liquidatedAmount = _amountNeeded;
         }
     }


### PR DESCRIPTION
requires: #141

This small change allows the user to specify the maximum amount of losses they are willing to sustain during a withdrawal (see #140). The default is 0%, so any realized loss will cause an abort