### PR TITLE
fix: various issues for release

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -276,9 +276,6 @@ abstract contract BaseStrategy {
      *  to the old address and begin flowing to this address once the change
      *  is in effect.
      *
-     *  This will not change any Strategy reports in progress, only
-     *  new reports made after this change goes into effect.
-     *
      *  This may only be called by the strategist.
      * @param _rewards The address to use for collecting rewards.
      */

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -184,6 +184,8 @@ abstract contract BaseStrategy {
 
     event UpdatedDebtThreshold(uint256 debtThreshold);
 
+    event EmergencyExitEnabled();
+
     // The minimum number of seconds between harvest calls. See
     // `setMinReportDelay()` for more details.
     uint256 public minReportDelay = 86400; // ~ once a day
@@ -659,6 +661,8 @@ abstract contract BaseStrategy {
     function setEmergencyExit() external onlyAuthorized {
         emergencyExit = true;
         vault.revokeStrategy();
+
+        emit EmergencyExitEnabled();
     }
 
     /**

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -186,9 +186,9 @@ abstract contract BaseStrategy {
 
     event EmergencyExitEnabled();
 
-    // The minimum number of seconds between harvest calls. See
-    // `setMinReportDelay()` for more details.
-    uint256 public minReportDelay = 86400; // ~ once a day
+    // The maximum number of seconds between harvest calls. See
+    // `setMaxReportDelay()` for more details.
+    uint256 public maxReportDelay = 86400; // ~ once a day
 
     // The minimum multiple that `callCost` must be above the credit/profit to
     // be "justifiable". See `setProfitFactor()` for more details.
@@ -287,18 +287,18 @@ abstract contract BaseStrategy {
 
     /**
      * @notice
-     *  Used to change `minReportDelay`. `minReportDelay` is the minimum number
-     *  of blocks that should pass before `harvest()` is called.
+     *  Used to change `maxReportDelay`. `maxReportDelay` is the maximum number
+     *  of blocks that should pass for `harvest()` to be called.
      *
-     *  For external keepers (such as the Keep3r network), this is the minimum
-     *  time between jobs, to prevent excessive costs. (see `harvestTrigger()`
+     *  For external keepers (such as the Keep3r network), this is the maximum
+     *  time between jobs to wait. (see `harvestTrigger()`
      *  for more details.)
      *
      *  This may only be called by governance or the strategist.
-     * @param _delay The minimum number of blocks to wait between harvests.
+     * @param _delay The maximum number of seconds to wait between harvests.
      */
-    function setMinReportDelay(uint256 _delay) external onlyAuthorized {
-        minReportDelay = _delay;
+    function setMaxReportDelay(uint256 _delay) external onlyAuthorized {
+        maxReportDelay = _delay;
         emit UpdatedReportDelay(_delay);
     }
 
@@ -508,7 +508,7 @@ abstract contract BaseStrategy {
      *  This call and `tendTrigger` should never return `true` at the
      *  same time.
      *
-     *  See `minReportDelay`, `profitFactor`, `debtThreshold` to adjust the
+     *  See `maxReportDelay`, `profitFactor`, `debtThreshold` to adjust the
      *  strategist-controlled parameters that will influence whether this call
      *  returns `true` or not. These parameters will be used in conjunction
      *  with the parameters reported to the Vault (see `params`) to determine
@@ -529,7 +529,7 @@ abstract contract BaseStrategy {
         if (params.activation == 0) return false;
 
         // Should trigger if hasn't been called in a while
-        if (block.timestamp.sub(params.lastReport) >= minReportDelay) return true;
+        if (block.timestamp.sub(params.lastReport) >= maxReportDelay) return true;
 
         // If some amount is owed, pay it back
         // NOTE: Since debt is based on deposits, it makes sense to guard against large

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -244,6 +244,7 @@ abstract contract BaseStrategy {
      * @param _strategist The new address to assign as `strategist`.
      */
     function setStrategist(address _strategist) external onlyAuthorized {
+        require(_strategist != address(0));
         strategist = _strategist;
         emit UpdatedStrategist(_strategist);
     }
@@ -262,6 +263,7 @@ abstract contract BaseStrategy {
      * @param _keeper The new address to assign as `keeper`.
      */
     function setKeeper(address _keeper) external onlyAuthorized {
+        require(_keeper != address(0));
         keeper = _keeper;
         emit UpdatedKeeper(_keeper);
     }
@@ -279,6 +281,7 @@ abstract contract BaseStrategy {
      * @param _rewards The address to use for collecting rewards.
      */
     function setRewards(address _rewards) external onlyStrategist {
+        require(_rewards != address(0));
         rewards = _rewards;
         emit UpdatedRewards(_rewards);
     }

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -59,16 +59,6 @@ interface VaultAPI is IERC20 {
     ) external returns (uint256);
 
     /**
-     * This function is used in the scenario where there is a newer Strategy
-     * that would hold the same positions as this one, and those positions are
-     * easily transferrable to the newer Strategy. These positions must be able
-     * to be transferred at the moment this call is made, if any prep is
-     * required to execute a full transfer in one transaction, that must be
-     * accounted for separately from this call.
-     */
-    function migrateStrategy(address _newStrategy) external;
-
-    /**
      * This function should only be used in the scenario where the Strategy is
      * being retired but no migration of the positions are possible, or in the
      * extreme scenario that the Strategy needs to be put into "Emergency Exit"

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -19,6 +19,8 @@ struct StrategyParams {
 interface VaultAPI is IERC20 {
     function apiVersion() external view returns (string memory);
 
+    function withdraw(uint256 shares, address recipient) external;
+
     function token() external view returns (address);
 
     function strategies(address _strategy) external view returns (StrategyParams memory);

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -92,7 +92,7 @@ struct StrategyParams:
     performanceFee: uint256  # Strategist's fee (basis points)
     activation: uint256  # Activation block.timestamp
     debtRatio: uint256  # Maximum borrow amount (in BPS of total assets)
-    rateLimit: uint256  # Max increase in debt per second since last harvest
+    rateLimit: uint256  # Limit on the increase of debt per unit time since last harvest
     lastReport: uint256  # block.timestamp of the last time a report occured
     totalDebt: uint256  # Total outstanding debt that Strategy has
     totalGain: uint256  # Total returns that Strategy has realized for Vault
@@ -102,7 +102,7 @@ struct StrategyParams:
 event StrategyAdded:
     strategy: indexed(address)
     debtRatio: uint256  # Maximum borrow amount (in BPS of total assets)
-    rateLimit: uint256  # Increase/decrease per block
+    rateLimit: uint256  # Limit on the increase of debt per unit time since last harvest
     performanceFee: uint256  # Strategist's fee (basis points)
 
 
@@ -1056,8 +1056,7 @@ def addStrategy(
     @param strategy The address of the Strategy to add.
     @param debtRatio The ratio of the total assets in the `vault that the `strategy` can manage.
     @param rateLimit
-        How many assets per block this Vault may deposit to or withdraw from
-        `strategy`.
+        Limit on the increase of debt per unit time since last harvest
     @param performanceFee
         The fee the strategist will receive based on this Vault's performance.
     """
@@ -1123,7 +1122,7 @@ def updateStrategyRateLimit(
 
         This may only be called by governance or management.
     @param strategy The Strategy to update.
-    @param rateLimit The quantity of assets `strategy` may now manage.
+    @param rateLimit Limit on the increase of debt per unit time since last harvest
     """
     assert msg.sender in [self.management, self.governance]
     assert self.strategies[strategy].activation > 0

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1176,7 +1176,7 @@ def migrateStrategy(oldVersion: address, newVersion: address):
     @param newVersion The new Strategy to migrate to.
     """
     assert msg.sender == self.governance
-
+    assert newVersion != ZERO_ADDRESS
     assert self.strategies[oldVersion].activation > 0
     assert self.strategies[newVersion].activation == 0
 

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1407,10 +1407,10 @@ def expectedReturn(strategy: address = msg.sender) -> uint256:
 
 
 @internal
-def _reportLoss(strategy: address, _loss: uint256):
+def _reportLoss(strategy: address, loss: uint256):
     # Loss can only be up the amount of debt issued to strategy
     totalDebt: uint256 = self.strategies[strategy].totalDebt
-    loss: uint256 = min(_loss, totalDebt)
+    assert totalDebt >= loss
     self.strategies[strategy].totalLoss += loss
     self.strategies[strategy].totalDebt = totalDebt - loss
     self.totalDebt -= loss

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -909,6 +909,7 @@ def maxAvailableShares() -> uint256:
 
 
 @external
+@nonreentrant("withdraw")
 def withdraw(_shares: uint256 = MAX_UINT256, recipient: address = msg.sender) -> uint256:
     """
     @notice

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -444,10 +444,13 @@ def setPerformanceFee(fee: uint256):
     @notice
         Used to change the value of `performanceFee`.
 
+        Should set this value below the maximum strategist performance fee.
+
         This may only be called by governance.
-    @param fee The new performance fee to use.
+    @param fee The new performance fee to use. 
     """
     assert msg.sender == self.governance
+    assert fee <= MAX_BPS 
     self.performanceFee = fee
     log UpdatePerformanceFee(fee)
 
@@ -462,6 +465,7 @@ def setManagementFee(fee: uint256):
     @param fee The new management fee to use.
     """
     assert msg.sender == self.governance
+    assert fee <= MAX_BPS 
     self.managementFee = fee
     log UpdateManagementFee(fee)
 
@@ -1061,6 +1065,7 @@ def addStrategy(
 
     assert msg.sender == self.governance
     assert self.debtRatio + debtRatio <= MAX_BPS
+    assert performanceFee <= MAX_BPS - self.performanceFee
     assert self.strategies[strategy].activation == 0
     assert self == Strategy(strategy).vault()
     assert self.token.address == Strategy(strategy).want()
@@ -1140,6 +1145,7 @@ def updateStrategyPerformanceFee(
     @param performanceFee The new fee the strategist will receive.
     """
     assert msg.sender == self.governance
+    assert performanceFee <= MAX_BPS - self.performanceFee
     assert self.strategies[strategy].activation > 0
     self.strategies[strategy].performanceFee = performanceFee
     log StrategyUpdatePerformanceFee(strategy, performanceFee)

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1057,6 +1057,7 @@ def addStrategy(
         The fee the strategist will receive based on this Vault's performance.
     """
     assert strategy != ZERO_ADDRESS
+    assert not self.emergencyShutdown
 
     assert msg.sender == self.governance
     assert self.debtRatio + debtRatio <= MAX_BPS

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -1341,7 +1341,7 @@ def _creditAvailable(strategy: address) -> uint256:
     # NOTE: Protect against unnecessary overflow faults here
     # NOTE: Set `strategy_rateLimit` to 0 to disable the rate limit
     if strategy_rateLimit > 0 and available / strategy_rateLimit >= delta:
-        available = min(available, strategy_rateLimit * delta)
+        available = strategy_rateLimit * delta
 
     # Can only borrow up to what the contract has in reserve
     # NOTE: Running near 100% is discouraged

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -51,7 +51,7 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
         ("strategist", "setStrategist", "gov", None),
         ("rewards", "setRewards", "strategist", None),
         ("keeper", "setKeeper", "strategist", None),
-        ("minReportDelay", "setMinReportDelay", "strategist", 1000),
+        ("maxReportDelay", "setMaxReportDelay", "strategist", 1000),
         ("profitFactor", "setProfitFactor", "strategist", 1000),
         ("debtThreshold", "setDebtThreshold", "strategist", 1000),
     ],

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -4,6 +4,8 @@ import yaml
 import pytest
 import brownie
 
+from brownie import ZERO_ADDRESS
+
 PACKAGE_VERSION = yaml.safe_load(
     (Path(__file__).parent.parent.parent.parent / "ethpm-config.yaml").read_text()
 )["version"]
@@ -86,3 +88,6 @@ def test_strategist_update(gov, strategist, strategy, rando):
     # But governance can
     strategy.setStrategist(strategist, {"from": gov})
     assert strategy.strategist() == strategist
+    # cannot set strategist to zero address
+    with brownie.reverts():
+        strategy.setStrategist(ZERO_ADDRESS, {"from": gov})

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -1,6 +1,8 @@
 import pytest
 import brownie
 
+FEE_MAX = 10_000
+
 
 def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     vault.setManagementFee(0, {"from": gov})
@@ -35,3 +37,29 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     assert vault.strategies(strategy).dict()["performanceFee"] == 0
     assert vault.balanceOf(rewards) == 0
     assert vault.balanceOf(strategist) == 0
+
+
+def test_max_fees(gov, vault, token, TestStrategy, rewards, strategist):
+    # performance fee should not be higher than MAX
+    vault.setPerformanceFee(FEE_MAX, {"from": gov})
+    with brownie.reverts():
+        vault.setPerformanceFee(FEE_MAX + 1, {"from": gov})
+
+    # management fee should not be higher than MAX
+    vault.setManagementFee(FEE_MAX, {"from": gov})
+
+    with brownie.reverts():
+        vault.setManagementFee(FEE_MAX + 1, {"from": gov})
+
+    # addStrategy should check for MAX FEE
+    strategy = strategist.deploy(TestStrategy, vault)
+    with brownie.reverts():
+        vault.addStrategy(strategy, 2_000, 1000, FEE_MAX + 1, {"from": gov})
+
+    # updateStrategyPerformanceFee should check for max to be MAX FEE - current performance fee
+    vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
+    vault_performance_fee = vault.performanceFee()
+    with brownie.reverts():
+        vault.updateStrategyPerformanceFee(
+            strategy, FEE_MAX - vault_performance_fee + 1, {"from": gov}
+        )

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -1,6 +1,6 @@
 import brownie
 
-ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+from brownie import ZERO_ADDRESS
 
 
 def test_good_migration(

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -1,5 +1,7 @@
 import brownie
 
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
 
 def test_good_migration(
     token, strategy, vault, gov, strategist, guardian, TestStrategy, rando
@@ -55,6 +57,10 @@ def test_bad_migration(
     # Can't migrate if you're not the Vault  or governance
     with brownie.reverts():
         strategy.migrate(new_strategy, {"from": rando})
+
+    # Can't migrate if new strategy is 0x0
+    with brownie.reverts():
+        vault.migrateStrategy(strategy, ZERO_ADDRESS, {"from": gov})
 
 
 def test_migrated_strategy_can_call_harvest(token, strategy, vault, gov, TestStrategy):

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -27,7 +27,7 @@ def test_harvest_tend_trigger(chain, gov, vault, token, TestStrategy):
 
     # Check that trigger works when it goes over time
     assert not strategy.harvestTrigger(0)
-    chain.mine(timestamp=chain.time() + strategy.minReportDelay())
+    chain.mine(timestamp=chain.time() + strategy.maxReportDelay())
     assert strategy.harvestTrigger(0)
     strategy.harvest({"from": gov})
 

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -272,6 +272,10 @@ def test_ordering(gov, vault, TestStrategy, rando):
     with brownie.reverts():
         vault.addStrategyToQueue(rando, {"from": gov})
 
+    # Can't add a strategy 0x0 to queue
+    with brownie.reverts():
+        vault.addStrategyToQueue(ZERO_ADDRESS, {"from": gov})
+
     vault.addStrategyToQueue(removed_strategy, {"from": gov})
     strategies.append(removed_strategy)
 


### PR DESCRIPTION
Change Log:
* adds check for shutdown flag in addStrat method. Audit Issue 5.1
* fix definition of reportDelay value setter and comments . Audit Issue 5.4
* sanity check for max fees. Audit Issue 5.6
* sanity check for adding 0x0 strat. Audit Issue 5.7
* fix sync rate limit comments. Audit Issue 5.18
* removes unused method in vault Api interface. Audit Issue 5.21
* add sanity checks to params. Audit Issue 5.22
* enforce loss report value with check. Audit Issue 5.24
* adds reentrancy guard and test to withdraw. Audit Issue 5.26
* removed superfluos min check. Audit Issue 5.36
* add event for emergency exit activation in strategy. Audit Open Q 6.2
* corrected comment on setRewards in `BaseStrategy`. Audit Open Q 6.5
 