### PR TITLE
feat: vault deposit limit zero on initialization

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -241,7 +241,8 @@ def initialize(
         deployed.
         The performance fee is set to 10% of yield, per Strategy.
         The management fee is set to 2%, per year.
-        There is no initial deposit limit.
+        There initial deposit limit is set to 0 (deposits disabled); it must be
+        updated after initialization.
     @dev
         If `nameOverride` is not specified, the name will be 'yearn'
         combined with the name of `token`.
@@ -278,8 +279,6 @@ def initialize(
     log UpdatePerformanceFee(convert(1000, uint256))
     self.managementFee = 200  # 2% per year
     log UpdateManagementFee(convert(200, uint256))
-    self.depositLimit = MAX_UINT256  # Start unlimited
-    log UpdateDepositLimit(MAX_UINT256)
     self.lastReport = block.timestamp
     self.activation = block.timestamp
     # EIP-712

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -241,7 +241,7 @@ def initialize(
         deployed.
         The performance fee is set to 10% of yield, per Strategy.
         The management fee is set to 2%, per year.
-        There initial deposit limit is set to 0 (deposits disabled); it must be
+        The initial deposit limit is set to 0 (deposits disabled); it must be
         updated after initialization.
     @dev
         If `nameOverride` is not specified, the name will be 'yearn'

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -30,6 +30,7 @@ def token(gov, Token):
 def vault(gov, guardian, management, token, rewards, Vault):
     vault = guardian.deploy(Vault)
     vault.initialize(token, gov, rewards, "", "", guardian)
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     vault.setManagement(management, {"from": gov})
     # Make it so vault has some AUM to start
     token.approve(vault, token.balanceOf(gov) // 2, {"from": gov})

--- a/tests/functional/registry/conftest.py
+++ b/tests/functional/registry/conftest.py
@@ -18,6 +18,7 @@ def create_vault(gov, create_token, patch_vault_version):
         vault.initialize(
             token, gov, gov, f"Yearn {token.name()} Vault", f"yv{token.symbol()}", gov
         )
+        vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
         assert vault.token() == token
         return vault
 

--- a/tests/functional/strategy/test_migration.py
+++ b/tests/functional/strategy/test_migration.py
@@ -43,6 +43,7 @@ def test_bad_migration(
     different_vault.initialize(
         token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
     )
+    different_vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     new_strategy = strategist.deploy(TestStrategy, different_vault)
 
     # Can't migrate to a strategy with a different vault

--- a/tests/functional/vault/test_config.py
+++ b/tests/functional/vault/test_config.py
@@ -31,7 +31,7 @@ def test_vault_deployment(guardian, gov, rewards, token, Vault):
     assert vault.apiVersion() == PACKAGE_VERSION
 
     assert vault.debtLimit() == 0
-    assert vault.depositLimit() == 2 ** 256 - 1
+    assert vault.depositLimit() == 0
     assert vault.creditAvailable() == 0
     assert vault.debtOutstanding() == 0
     assert vault.maxAvailableShares() == 0

--- a/tests/functional/vault/test_losses.py
+++ b/tests/functional/vault/test_losses.py
@@ -11,6 +11,7 @@ def vault(gov, token, Vault):
     vault.initialize(
         token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     yield vault
 
 

--- a/tests/functional/vault/test_shares.py
+++ b/tests/functional/vault/test_shares.py
@@ -9,6 +9,7 @@ def vault(gov, token, Vault):
     vault.initialize(
         token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     yield vault
 
 

--- a/tests/functional/vault/test_strategies.py
+++ b/tests/functional/vault/test_strategies.py
@@ -12,6 +12,7 @@ def vault(gov, token, Vault):
     vault.initialize(
         token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     yield vault
 
 
@@ -39,6 +40,7 @@ def wrong_strategy(gov, Vault, Token, TestStrategy):
         "yv" + otherToken.symbol(),
         gov,
     )
+    otherVault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     yield gov.deploy(TestStrategy, otherVault)
 
 

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -13,6 +13,7 @@ def test_multiple_withdrawals(chain, token, gov, Vault, TestStrategy):
         gov,
         {"from": gov},
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
     starting_balance = token.balanceOf(gov)
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(5)]
     [
@@ -102,6 +103,7 @@ def test_progressive_withdrawal(
     vault.initialize(
         token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
 
     strategies = [gov.deploy(TestStrategy, vault) for _ in range(2)]
     [vault.addStrategy(s, 1000, 10, 1000, {"from": gov}) for s in strategies]
@@ -156,6 +158,7 @@ def test_withdrawal_with_empty_queue(
     vault.initialize(
         token, gov, rewards, token.symbol() + " yVault", "yv" + token.symbol(), guardian
     )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
 
     strategy = gov.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 1000, 10, 1000, {"from": gov})

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -53,6 +53,8 @@ def create_vault(gov, rewards, guardian, create_token, patch_vault_version):
             "yv" + token.symbol(),
             guardian,
         )
+        vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
+        assert vault.depositLimit() == 2 ** 256 - 1
         assert vault.token() == token
         return vault
 


### PR DESCRIPTION
fixes #121 

- Remove set deposit limit to `2 ** 256 - 1` in `initialize`
- By default, deposit limit is `0` on construction (must call `setDepositLimit` afterwards to enable deposits)
- Removes `UpdateDepositLimit` event in `initialize`
- Updates all necessary tests & documentation