### PR TITLE
Deploy script improvements

### DIFF
--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -57,7 +57,13 @@ def main():
         use_proxy = True
 
     token = Token.at(get_address("ERC20 Token"))
-    gov = get_address("Yearn Governance", default="ychad.eth")
+
+    if use_proxy:
+        gov_default = dev.address
+    else:
+        gov_default = "ychad.eth"
+    gov = get_address("Yearn Governance", default=gov_default)
+
     rewards = get_address(
         "Rewards contract", default="0x93A62dA5a14C80f265DAbC077fCEE437B1a0Efde"
     )
@@ -90,7 +96,7 @@ def main():
         ]
         if use_proxy:
             # NOTE: Must always include guardian, even if default
-            args.insert(3, guardian)
+            args.insert(2, guardian)
             txn_receipt = registry.newExperimentalVault(*args, {"from": dev})
             vault = Vault.at(txn_receipt.events["NewExperimentalVault"]["vault"])
             click.echo(f"Experimental Vault deployed [{vault.address}]")


### PR DESCRIPTION
The `newExperimentalVault(...)` function in the [current registry contract](https://etherscan.io/address/0xe15461b18ee31b7379019dc523231c57d1cbc18c#writeContract) expects `guardian` at argument index 2 instead of 3.

Also when deploying experimental vaults, default `governance` to the `dev` address to make it easier to set it up.