### PR TITLE
feat: pull strategist rewards rather than push

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -280,12 +280,11 @@ abstract contract BaseStrategy {
 
     /**
      * @notice
-     *  Used to change `rewards`. Any distributed rewards will cease flowing
-     *  to the old address and begin flowing to this address once the change
-     *  is in effect.
+     *  Used to change `rewards`. EOA or smart contract which has the permission
+     *  to pull rewards from the vault.
      *
      *  This may only be called by the strategist.
-     * @param _rewards The address to use for collecting rewards.
+     * @param _rewards The address to use for pulling rewards.
      */
     function setRewards(address _rewards) external onlyStrategist {
         require(_rewards != address(0));
@@ -463,16 +462,6 @@ abstract contract BaseStrategy {
     function liquidatePosition(uint256 _amountNeeded) internal virtual returns (uint256 _liquidatedAmount, uint256 _loss);
 
     /**
-     *  `Harvest()` calls this function after shares are created during
-     *  `vault.report()`. You can customize this function to any share
-     *  distribution mechanism you want.
-     *
-     *   See `vault.report()` for further details.
-     */
-    function distributeRewards() internal virtual {
-    }
-
-    /**
      * @notice
      *  Provide a signal to the keeper that `tend()` should be called. The
      *  keeper will provide the estimated gas cost that they would pay to call
@@ -613,9 +602,6 @@ abstract contract BaseStrategy {
         // which is the amount it has earned since the last time it reported to
         // the Vault.
         debtOutstanding = vault.report(profit, loss, debtPayment);
-
-        // Distribute any reward shares earned by the strategy on this report
-        distributeRewards();
 
         // Check if free returns are left, and re-invest them
         adjustPosition(debtOutstanding);

--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -243,6 +243,7 @@ abstract contract BaseStrategy {
         strategist = msg.sender;
         rewards = msg.sender;
         keeper = msg.sender;
+        vault.approve(rewards, uint256(-1)); // Allow rewards to be pulled
     }
 
     /**
@@ -288,7 +289,9 @@ abstract contract BaseStrategy {
      */
     function setRewards(address _rewards) external onlyStrategist {
         require(_rewards != address(0));
+        vault.approve(rewards, 0);
         rewards = _rewards;
+        vault.approve(rewards, uint256(-1));
         emit UpdatedRewards(_rewards);
     }
 
@@ -467,11 +470,6 @@ abstract contract BaseStrategy {
      *   See `vault.report()` for further details.
      */
     function distributeRewards() internal virtual {
-        // Transfer 100% of newly-minted shares awarded to this contract to the rewards address.
-        uint256 balance = vault.balanceOf(address(this));
-        if (balance > 0) {
-            vault.transfer(rewards, balance);
-        }
     }
 
     /**

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -8,11 +8,12 @@ def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     vault.setManagementFee(0, {"from": gov})
     vault.setPerformanceFee(450, {"from": gov})
 
+    strategy = strategist.deploy(TestStrategy, vault)
+    vault.addStrategy(strategy, 2_000, 1000, 50, {"from": gov})
+
     assert vault.balanceOf(rewards) == 0
     assert vault.balanceOf(strategy) == 0
 
-    strategy = strategist.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 2_000, 1000, 50, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
     strategy.harvest({"from": strategist})
 
@@ -24,11 +25,12 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     vault.setManagementFee(0, {"from": gov})
     vault.setPerformanceFee(0, {"from": gov})
 
+    strategy = strategist.deploy(TestStrategy, vault)
+    vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
+
     assert vault.balanceOf(rewards) == 0
     assert vault.balanceOf(strategy) == 0
 
-    strategy = strategist.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
     token.transfer(strategy, 10 ** 8, {"from": gov})
     strategy.harvest({"from": strategist})
 

--- a/tests/functional/strategy/test_fees.py
+++ b/tests/functional/strategy/test_fees.py
@@ -9,7 +9,7 @@ def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     vault.setPerformanceFee(450, {"from": gov})
 
     assert vault.balanceOf(rewards) == 0
-    assert vault.balanceOf(strategist) == 0
+    assert vault.balanceOf(strategy) == 0
 
     strategy = strategist.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 2_000, 1000, 50, {"from": gov})
@@ -17,7 +17,7 @@ def test_performance_fees(gov, vault, token, TestStrategy, rewards, strategist):
     strategy.harvest({"from": strategist})
 
     assert vault.balanceOf(rewards) == 0.045 * 1e8
-    assert vault.balanceOf(strategist) == 0.005 * 1e8
+    assert vault.balanceOf(strategy) == 0.005 * 1e8
 
 
 def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
@@ -25,7 +25,7 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     vault.setPerformanceFee(0, {"from": gov})
 
     assert vault.balanceOf(rewards) == 0
-    assert vault.balanceOf(strategist) == 0
+    assert vault.balanceOf(strategy) == 0
 
     strategy = strategist.deploy(TestStrategy, vault)
     vault.addStrategy(strategy, 2_000, 1000, 0, {"from": gov})
@@ -36,7 +36,7 @@ def test_zero_fees(gov, vault, token, TestStrategy, rewards, strategist):
     assert vault.performanceFee() == 0
     assert vault.strategies(strategy).dict()["performanceFee"] == 0
     assert vault.balanceOf(rewards) == 0
-    assert vault.balanceOf(strategist) == 0
+    assert vault.balanceOf(strategy) == 0
 
 
 def test_max_fees(gov, vault, token, TestStrategy, rewards, strategist):


### PR DESCRIPTION
This change sets approval to allow strategists to withdraw vault LP tokens from the vault using transferFrom rather than having them distributed on every harvest. 

This saves gas by not distributing every harvest. 

It also solves a problem with the [strategist sharer contract](https://github.com/Grandthrax/Sharer/blob/master/contracts/SharerV2.sol). We cannot tell which contract sent the rewards and so cannot differentiate between rewards from different strategies on the same vault. 