### PR TITLE
 fix: reentrancy guard test not failing correctly

### DIFF
--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -249,12 +249,14 @@ def test_withdrawal_with_reentrancy(
     token.approve(vault, 2 ** 256 - 1, {"from": gov})
     vault.deposit(1000, {"from": gov})
 
-    # To simulate reentrancy we need strategy to have some balance
-    vault.transfer(strategy, vault.balanceOf(gov) // 2, {"from": gov})
-
     # move funds into strategy
     chain.sleep(1)  # Needs to be a second ahead, at least
     strategy.harvest({"from": gov})
+
+    # To simulate reentrancy we need strategy to have some balance
+    vault.transfer(strategy, vault.balanceOf(gov) // 2, {"from": gov})
+
+    assert vault.balanceOf(strategy) > 0
 
     # given previous setup the withdraw should revert from reentrancy guard
     with brownie.reverts():

--- a/tests/functional/vault/test_withdrawal.py
+++ b/tests/functional/vault/test_withdrawal.py
@@ -242,7 +242,7 @@ def test_withdrawal_with_reentrancy(
     vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
 
     strategy = gov.deploy(TestStrategy, vault)
-    vault.addStrategy(strategy, 1000, 10, 1000, {"from": gov})
+    vault.addStrategy(strategy, 10_000, 0, 1000, {"from": gov})
 
     strategy._toggleReentrancyExploit()
 


### PR DESCRIPTION
Issue #176 

Created PR for discussion @fubuloubu. At first glance it seems reentrancy guard is not working as expected,
can check out branch and run the test `test_withdrawal_with_reentrancy`. 

Issue:
  Withdraw transaction in `test_withdrawal_with_reentrancy` is not failing as expected.

Expectation: 
  Withdraw transaction should fail, when we setup strategy for reentrancy back to vault.
  
  
  
<img width="1006" alt="Screen Shot 2021-01-30 at 08 26 38" src="https://user-images.githubusercontent.com/6074987/106358951-e46efd80-62d4-11eb-9cc5-b51c30cc79cf.png">

  
  
