### PR TITLE
test: increase Registry test coverage

### DIFF
--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -29,28 +29,14 @@ def test_registry_setGovernance(gov, registry, rando):
         registry.acceptGovernance({"from": gov})
 
 
-def test_banksy(gov, guardian, rewards, registry, create_token, create_vault, rando):
-
-    # Not just anyone can create a new endorsed Vault, only governance can!
-    with brownie.reverts():
-        registry.newVault(create_token(), guardian, rewards, "", "", {"from": rando})
-
+def test_banksy(gov, registry, create_vault, rando):
     vault = create_vault()
-
-    # Not just anyone can create a new Release either
-    with brownie.reverts():
-        registry.newRelease(vault, {"from": rando})
-
     registry.newRelease(vault)
     assert registry.tags(vault) == ""
 
-    # Not just anyone can tag a Vault either
+    # Not just anyone can tag a Vault, only a Banksy can!
     with brownie.reverts():
         registry.tagVault(vault, "Anything I want!", {"from": rando})
-
-    # Not just anyone can endorse a Vault either
-    with brownie.reverts():
-        registry.endorseVault(vault, {"from": rando})
 
     # Not just anyone can become a banksy either
     with brownie.reverts():

--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -29,14 +29,28 @@ def test_registry_setGovernance(gov, registry, rando):
         registry.acceptGovernance({"from": gov})
 
 
-def test_banksy(gov, registry, create_vault, rando):
+def test_banksy(gov, guardian, rewards, registry, create_token, create_vault, rando):
+
+    # Not just anyone can create a new Vault, only a Banksy can!
+    with brownie.reverts():
+        registry.newVault(create_token(), guardian, rewards, "", "", {"from": rando})
+
     vault = create_vault()
+
+    # Not just anyone can create a new Release either
+    with brownie.reverts():
+        registry.newRelease(vault, {"from": rando})
+
     registry.newRelease(vault)
     assert registry.tags(vault) == ""
 
-    # Not just anyone can tag a Vault, only a Banksy can!
+    # Not just anyone can tag a Vault either
     with brownie.reverts():
         registry.tagVault(vault, "Anything I want!", {"from": rando})
+
+    # Not just anyone can endorse a Vault either
+    with brownie.reverts():
+        registry.endorseVault(vault, {"from": rando})
 
     # Not just anyone can become a banksy either
     with brownie.reverts():

--- a/tests/functional/registry/test_config.py
+++ b/tests/functional/registry/test_config.py
@@ -31,7 +31,7 @@ def test_registry_setGovernance(gov, registry, rando):
 
 def test_banksy(gov, guardian, rewards, registry, create_token, create_vault, rando):
 
-    # Not just anyone can create a new Vault, only a Banksy can!
+    # Not just anyone can create a new endorsed Vault, only governance can!
     with brownie.reverts():
         registry.newVault(create_token(), guardian, rewards, "", "", {"from": rando})
 

--- a/tests/functional/registry/test_deployment.py
+++ b/tests/functional/registry/test_deployment.py
@@ -2,13 +2,20 @@ import brownie
 
 
 def test_deployment_management(
-    gov, guardian, rewards, registry, Vault, create_token, create_vault
+    gov, guardian, rewards, registry, Vault, create_token, create_vault, rando
 ):
     token = create_token()
 
     # No deployments yet for token
     with brownie.reverts():
         registry.latestVault(token)
+
+    # Check that newRelease raises if vault governance is a rando
+    bad_vault = create_vault()
+    bad_vault.setGovernance(rando)
+    bad_vault.acceptGovernance({"from": rando})
+    with brownie.reverts():
+        registry.newRelease(bad_vault, {"from": gov})
 
     # Creating the first deployment makes `latestVault()` work
     v1_vault = create_vault(token, version="1.0.0")

--- a/tests/functional/registry/test_release.py
+++ b/tests/functional/registry/test_release.py
@@ -1,10 +1,15 @@
 import brownie
 
 
-def test_release_management(gov, registry, create_vault):
+def test_release_management(gov, registry, create_vault, rando):
     # No releases yet
     with brownie.reverts():
         registry.latestRelease()
+
+    # Not just anyone can create a new Release
+    vault = create_vault()
+    with brownie.reverts():
+        registry.newRelease(vault, {"from": rando})
 
     # Creating the first release makes `latestRelease()` work
     v1_vault = create_vault(version="1.0.0")
@@ -23,3 +28,10 @@ def test_release_management(gov, registry, create_vault):
     # Can only endorse the latest release.
     with brownie.reverts():
         registry.endorseVault(v1_vault)
+
+    # Check that newRelease raises if vault governance is a rando
+    bad_vault = create_vault()
+    bad_vault.setGovernance(rando)
+    bad_vault.acceptGovernance({"from": rando})
+    with brownie.reverts():
+        registry.newRelease(bad_vault, {"from": gov})

--- a/tests/functional/registry/test_release.py
+++ b/tests/functional/registry/test_release.py
@@ -19,3 +19,7 @@ def test_release_management(gov, registry, create_vault):
     v2_vault = create_vault(version="2.0.0")
     registry.newRelease(v2_vault, {"from": gov})
     assert registry.latestRelease() == v2_vault.apiVersion() == "2.0.0"
+
+    # Can only endorse the latest release.
+    with brownie.reverts():
+        registry.endorseVault(v1_vault)


### PR DESCRIPTION
Increases Registry test coverage to 100%. In particular, there was some missing
branch coverage in the following:
* Registry.newRelease()
* Registry.newVault()
* Registry.endorseVault()

The missing branch coverage was all on asserts, so this change just creates
some negative tests to check for reverts.

Partial work towards #156.