### PR TITLE
Add minime style token balance snapshots

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -951,7 +951,11 @@ def _shareValue(shares: uint256) -> uint256:
     # Determines the current value of `shares`.
     # NOTE: if sqrt(Vault.totalAssets()) > 1e37, this could potentially revert
     # NOTE: using 1e3 for extra precision here, when decimals is low
-    return ((10 ** 3 * (shares * self._totalAssets())) / self.totalSupply) / 10 ** 3
+    totalSupply: uint256 = self.totalSupply
+    if totalSupply == 0:
+        return 0
+    else:
+        return ((10 ** 3 * (shares * self._totalAssets())) / totalSupply) / 10 ** 3
 
 
 @view

--- a/tests/functional/vault/test_snapshot.py
+++ b/tests/functional/vault/test_snapshot.py
@@ -1,0 +1,47 @@
+import pytest
+
+
+@pytest.fixture
+def vault(gov, token, Vault):
+    # NOTE: Overriding the one in conftest because it has values already
+    vault = gov.deploy(Vault)
+    vault.initialize(
+        token, gov, gov, token.symbol() + " yVault", "yv" + token.symbol(), gov
+    )
+    vault.setDepositLimit(2 ** 256 - 1, {"from": gov})
+    yield vault
+
+
+def test_deposit_transfer_withdraw(chain, gov, vault, token, rando):
+    starting_block = len(chain) - 1
+
+    balance = token.balanceOf(gov)
+    token.approve(vault, balance, {"from": gov})
+    vault.deposit(balance // 2, {"from": gov})
+    bal = vault.balanceOf(gov)
+
+    assert vault.balanceOfAt(gov, starting_block) == 0
+    assert vault.balanceOfAt(gov, starting_block + 2) == bal
+
+    # Do it twice to test behavior when it has shares
+    vault.deposit({"from": gov})
+    assert vault.balanceOfAt(gov, starting_block + 2) == bal
+    bal = vault.balanceOf(gov)
+    assert vault.balanceOfAt(gov, starting_block + 3) == bal
+    assert vault.totalSupplyAt(starting_block + 3) == bal
+
+    vault.transfer(rando, bal // 2, {"from": gov})
+    assert vault.balanceOfAt(gov, starting_block + 3) == bal
+    bal = vault.balanceOf(gov)
+    bal2 = vault.balanceOf(rando)
+    assert vault.balanceOfAt(gov, starting_block + 4) == bal
+    assert vault.balanceOfAt(rando, starting_block + 3) == 0
+    assert vault.balanceOfAt(rando, starting_block + 4) == bal2
+
+    vault.withdraw({"from": gov})
+    vault.withdraw({"from": rando})
+
+    assert vault.balanceOfAt(gov, starting_block + 6) == 0
+    assert vault.balanceOfAt(rando, starting_block + 6) == 0
+    assert vault.totalSupplyAt(starting_block + 5) == bal2
+    assert vault.totalSupplyAt(starting_block + 6) == 0

--- a/tests/integration/test_snapshot.py
+++ b/tests/integration/test_snapshot.py
@@ -90,5 +90,11 @@ class SnapshotHistory:
 
 def test_snapshots(chain, accounts, token, vault, state_machine):
     state_machine(
-        SnapshotHistory, chain, accounts, token, vault,
+        SnapshotHistory,
+        chain,
+        accounts,
+        token,
+        vault,
+        # NOTE: Taking too long with default settings
+        settings={"max_examples": 20, "stateful_step_count": 6},
     )

--- a/tests/integration/test_snapshot.py
+++ b/tests/integration/test_snapshot.py
@@ -1,0 +1,94 @@
+import brownie
+from brownie.test import strategy
+
+
+class SnapshotHistory:
+
+    st_accounts = strategy("address")
+    st_decimals = strategy("decimal", min_value="0.1", max_value="0.9")
+
+    def __init__(self, chain, accounts, token, vault):
+        self.chain = chain
+        self.accounts = accounts
+        self.token = token
+        self.vault = vault
+
+        # Some setup checks
+        balance = token.balanceOf(accounts[0])
+        assert balance > 0
+        # NOTE: Redistribute some wealth so test is interesting
+        [token.transfer(a, balance // 10, {"from": accounts[0]}) for a in accounts[1:]]
+        # NOTE: Assume Vault starts with no deposits
+        assert max(vault.balanceOf(a) for a in accounts) == 0
+
+    def setup(self):
+        self.balance_history = [{a: 0 for a in self.accounts}] * len(self.chain)
+
+    def initialize(self, ratio="st_decimals"):
+        # Have everyone deposit some amount
+        for a in self.accounts:
+            self.rule_deposit(a, ratio)
+
+    def record_balances(self):
+        self.balance_history.append({a: self.vault.balanceOf(a) for a in self.accounts})
+
+    def rule_nothing(self):
+        print("No action")
+        self.chain.mine()
+        self.record_balances()
+
+    def rule_deposit(self, a="st_accounts", ratio="st_decimals"):
+        amt = int(self.token.balanceOf(a) * ratio)
+        print(f"Vault.deposit({amt}, from={a})")
+
+        self.token.approve(self.vault, amt, {"from": a})
+        self.record_balances()
+
+        if amt > 0:
+            self.vault.deposit(amt, {"from": a})
+
+        else:
+            with brownie.reverts():
+                self.vault.deposit(amt, {"from": a})
+
+        self.record_balances()
+
+    def rule_transfer(self, a="st_accounts", b="st_accounts", ratio="st_decimals"):
+        amt = int(self.vault.balanceOf(a) * ratio)
+        print(f"Vault.transfer({b}, {amt}, from={a})")
+
+        self.vault.transfer(b, amt, {"from": a})
+        self.record_balances()
+
+    def rule_transferFrom(
+        self, a="st_accounts", b="st_accounts", c="st_accounts", ratio="st_decimals",
+    ):
+        amt = int(self.vault.balanceOf(a) * ratio)
+        print(f"Vault.transferFrom({a}, {b}, {amt}, from={c})")
+
+        self.vault.approve(c, amt, {"from": a})
+        self.record_balances()
+
+        self.vault.transferFrom(a, b, amt, {"from": c})
+        self.record_balances()
+
+    def rule_withdraw(self, a="st_accounts", ratio="st_decimals"):
+        amt = int(self.vault.balanceOf(a) * ratio)
+        print(f"Vault.withdraw({amt}, from={a})")
+
+        self.vault.withdraw(amt, {"from": a})
+        self.record_balances()
+
+    def invariant_balance_balance_history(self):
+        for blk in range(len(self.chain)):
+            balance_history = self.balance_history[blk]
+            assert sum(balance_history.values()) == self.vault.totalSupplyAt(blk)
+
+            for acct, balance in balance_history.items():
+                assert self.vault.balanceOfAt(acct, blk) == balance
+
+
+def test_snapshots(chain, accounts, token, vault, state_machine):
+    state_machine(
+        SnapshotHistory, chain, accounts, token, vault,
+    )


### PR DESCRIPTION
This is a solution to [issue 170](https://github.com/iearn-finance/yearn-vaults/issues/170) to add token balance tracking to the vaults. It tracks user balances with `SnapshotEvents` and the total supply when that value is changed by vault deposits or withdraws.