### PR TITLE
feat: proxy mode support for BaseStrategy via BaseStrategyInitializable

### DIFF
--- a/contracts/BaseStrategy.sol
+++ b/contracts/BaseStrategy.sol
@@ -255,6 +255,8 @@ abstract contract BaseStrategy {
         address _rewards,
         address _keeper
     ) internal {
+        require(address(want) == address(0), "Strategy already initialized");
+
         vault = VaultAPI(_vault);
         want = IERC20(vault.token());
         want.safeApprove(_vault, uint256(-1)); // Give Vault unlimited access (might save gas)

--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -2,14 +2,14 @@
 pragma solidity 0.6.12;
 pragma experimental ABIEncoderV2;
 
-import {BaseStrategy, StrategyParams, VaultAPI} from "../BaseStrategy.sol";
+import {BaseStrategyInitializable, StrategyParams, VaultAPI} from "../BaseStrategy.sol";
 
 /*
  * This Strategy serves as both a mock Strategy for testing, and an example
  * for integrators on how to use BaseStrategy
  */
 
-contract TestStrategy is BaseStrategy {
+contract TestStrategy is BaseStrategyInitializable {
     bool public doReentrancy;
 
     // Some token that needs to be protected for some reason
@@ -17,7 +17,7 @@ contract TestStrategy is BaseStrategy {
     // to test `BaseStrategy.protectedTokens()`
     address public constant protectedToken = address(0xbad);
 
-    constructor(address _vault) public BaseStrategy(_vault) {}
+    constructor(address _vault) public BaseStrategyInitializable(_vault) {}
 
     function name() external override view returns (string memory) {
         return string(abi.encodePacked("TestStrategy ", apiVersion()));

--- a/contracts/utils/ProxyFactoryInitializable.sol
+++ b/contracts/utils/ProxyFactoryInitializable.sol
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity 0.6.12;
+
+contract ProxyFactoryInitializable {
+    event ProxyCreated(address indexed proxy, bytes returnData);
+
+    function deployMinimal(address _logic, bytes memory _data) external returns (address proxy, bytes memory returnData) {
+        // Adapted from https://github.com/optionality/clone-factory/blob/32782f82dfc5a00d103a7e61a17a5dedbd1e8e9d/contracts/CloneFactory.sol
+        bytes20 targetBytes = bytes20(_logic);
+        assembly {
+            let clone := mload(0x40)
+            mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+            mstore(add(clone, 0x14), targetBytes)
+            mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+            proxy := create(0, clone, 0x37)
+        }
+
+        if (_data.length > 0) {
+            bool success = false;
+            (success, returnData) = proxy.call(_data);
+            if (!success) {
+                string memory _revertMsg = _getRevertMsg(returnData);
+                revert(_revertMsg);
+            }
+        }
+
+        emit ProxyCreated(address(proxy), returnData);
+    }
+
+    /// @dev Get the revert message from a call
+    /// @notice This is needed in order to get the human-readable revert message from a call
+    /// @param _res Response of the call
+    /// @return Revert message string
+    function _getRevertMsg(bytes memory _res) internal pure returns (string memory) {
+        // If the _res length is less than 68, then the transaction failed silently (without a revert message)
+        if (_res.length < 68) return "Transaction reverted silently";
+        bytes memory revertData = slice(_res, 4, _res.length - 4); // Remove the selector which is the first 4 bytes
+        return abi.decode(revertData, (string)); // All that remains is the revert string
+    }
+
+    function slice(
+        bytes memory _bytes,
+        uint256 _start,
+        uint256 _length
+    ) internal pure returns (bytes memory) {
+        require(_length + 31 >= _length, "slice_overflow");
+        require(_start + _length >= _start, "slice_overflow");
+        require(_bytes.length >= _start + _length, "slice_outOfBounds");
+
+        bytes memory tempBytes;
+
+        assembly {
+            switch iszero(_length)
+                case 0 {
+                    // Get a location of some free memory and store it in tempBytes as
+                    // Solidity does for memory variables.
+                    tempBytes := mload(0x40)
+
+                    // The first word of the slice result is potentially a partial
+                    // word read from the original array. To read it, we calculate
+                    // the length of that partial word and start copying that many
+                    // bytes into the array. The first word we copy will start with
+                    // data we don't care about, but the last `lengthmod` bytes will
+                    // land at the beginning of the contents of the new array. When
+                    // we're done copying, we overwrite the full first word with
+                    // the actual length of the slice.
+                    let lengthmod := and(_length, 31)
+
+                    // The multiplication in the next line is necessary
+                    // because when slicing multiples of 32 bytes (lengthmod == 0)
+                    // the following copy loop was copying the origin's length
+                    // and then ending prematurely not copying everything it should.
+                    let mc := add(add(tempBytes, lengthmod), mul(0x20, iszero(lengthmod)))
+                    let end := add(mc, _length)
+
+                    for {
+                        // The multiplication in the next line has the same exact purpose
+                        // as the one above.
+                        let cc := add(add(add(_bytes, lengthmod), mul(0x20, iszero(lengthmod))), _start)
+                    } lt(mc, end) {
+                        mc := add(mc, 0x20)
+                        cc := add(cc, 0x20)
+                    } {
+                        mstore(mc, mload(cc))
+                    }
+
+                    mstore(tempBytes, _length)
+
+                    //update free-memory pointer
+                    //allocating the array padded to 32 bytes like the compiler does now
+                    mstore(0x40, and(add(mc, 31), not(31)))
+                }
+                //if we want a zero-length slice let's just return a zero-length array
+                default {
+                    tempBytes := mload(0x40)
+
+                    mstore(0x40, add(tempBytes, 0x20))
+                }
+        }
+
+        return tempBytes;
+    }
+}

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -77,7 +77,7 @@ def strategy(
         # strategy proxy address is returned in the event ProxyCreated
         strategyAddress = tx.events["ProxyCreated"]["proxy"]
         # redefine strategy as the new proxy deployed
-        strategy = TestStrategy.at(strategyAddress)
+        strategy = TestStrategy.at(strategyAddress, owner=strategist)
 
     strategy.setKeeper(keeper, {"from": strategist})
     vault.addStrategy(

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -33,6 +33,13 @@ def test_strategy_deployment(strategist, vault, TestStrategy):
     assert not strategy.tendTrigger(0)
 
 
+def test_strategy_no_reinit(strategist, vault, TestStrategy):
+    strategy = strategist.deploy(TestStrategy, vault)
+
+    with brownie.reverts("Strategy already initialized"):
+        strategy.initialize(vault, strategist, strategist, strategist)
+
+
 def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
     # Only governance or strategist can set this param
     with brownie.reverts():


### PR DESCRIPTION
Reduce deployment costs if you have template strategies. Instead of inherit, delegate storage for params to minimal proxies.

e.g. https://github.com/emilianobonassi/yIdleStrategies/blob/dev/contracts/StrategyIdle.sol