### PR TITLE
test: increase coverage for BaseStrategy.sweep()

### DIFF
--- a/contracts/test/TestStrategy.sol
+++ b/contracts/test/TestStrategy.sol
@@ -12,6 +12,11 @@ import {BaseStrategy, StrategyParams, VaultAPI} from "../BaseStrategy.sol";
 contract TestStrategy is BaseStrategy {
     bool public doReentrancy;
 
+    // Some token that needs to be protected for some reason
+    // Initialize this to some fake address, because we're just using it
+    // to test `BaseStrategy.protectedTokens()`
+    address public constant protectedToken = address(0xbad);
+
     constructor(address _vault) public BaseStrategy(_vault) {}
 
     function name() external override view returns (string memory) {
@@ -92,6 +97,8 @@ contract TestStrategy is BaseStrategy {
     }
 
     function protectedTokens() internal override view returns (address[] memory) {
-        return new address[](0); // No additional tokens/tokenized positions for mock
+        address[] memory protected = new address[](1);
+        protected[0] = protectedToken;
+        return protected;
     }
 }


### PR DESCRIPTION
Currently, `TestStrategy` does not have any protected tokens. In order to get full test coverage of `BaseStrategy.sweep()`, this change adds a (fake) protected token address to `TestStrategy` and tests sweep on that address, checking for a revert.

It also tests that sweep reverts if given the vault shares address.

Partial progress towards #156.
