### PR TITLE
test: increase coverage of BaseStrategy

### DIFF
--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -90,7 +90,7 @@ def test_strategy_setParams(
     setter,
     caller,
     val,
-    guard_allowed,
+    strategist_allowed,
     authority_error,
 ):
     if val is None:

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -57,9 +57,23 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
         ("rewards", "setRewards", "gov", None, False, "!strategist"),
         ("keeper", "setKeeper", "strategist", None, True, "!authorized"),
         ("keeper", "setKeeper", "gov", None, True, "!authorized"),
-        ("minReportDelay", "setMinReportDelay", "strategist", 1000, True, "!authorized"),
+        (
+            "minReportDelay",
+            "setMinReportDelay",
+            "strategist",
+            1000,
+            True,
+            "!authorized",
+        ),
         ("minReportDelay", "setMinReportDelay", "gov", 2000, True, "!authorized"),
-        ("maxReportDelay", "setMaxReportDelay", "strategist", 1000, True, "!authorized"),
+        (
+            "maxReportDelay",
+            "setMaxReportDelay",
+            "strategist",
+            1000,
+            True,
+            "!authorized",
+        ),
         ("maxReportDelay", "setMaxReportDelay", "gov", 2000, True, "!authorized"),
         ("profitFactor", "setProfitFactor", "strategist", 1000, True, "!authorized"),
         ("profitFactor", "setProfitFactor", "gov", 2000, True, "!authorized"),
@@ -68,7 +82,16 @@ def test_strategy_setEmergencyExit(strategy, gov, strategist, rando, chain):
     ],
 )
 def test_strategy_setParams(
-    gov, strategist, strategy, rando, getter, setter, caller, val, guard_allowed, authority_error
+    gov,
+    strategist,
+    strategy,
+    rando,
+    getter,
+    setter,
+    caller,
+    val,
+    guard_allowed,
+    authority_error,
 ):
     if val is None:
         # Can't access fixtures, so use None to mean any random address

--- a/tests/functional/strategy/test_config.py
+++ b/tests/functional/strategy/test_config.py
@@ -109,7 +109,7 @@ def test_strategy_setParams(
         getattr(strategy, setter)(val, {"from": caller})
         assert getattr(strategy, getter)() == val
 
-        getattr(strategy, setter)(prev_val, {"from": caller})
+        getattr(strategy, setter)(prev_val, {"from": gov})
         assert getattr(strategy, getter)() == prev_val
     else:
         with brownie.reverts(authority_error):

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -138,11 +138,13 @@ def test_reject_ether(gov, strategy):
         gov.transfer(strategy, 1)
 
 
-def test_set_metadataURI(gov, strategy, rando):
+def test_set_metadataURI(gov, strategy, strategist, rando):
     assert strategy.metadataURI() == ""  # Empty by default
     strategy.setMetadataURI("ipfs://test", {"from": gov})
     assert strategy.metadataURI() == "ipfs://test"
     strategy.setMetadataURI("ipfs://test2", {"from": gov})
     assert strategy.metadataURI() == "ipfs://test2"
-    with brownie.reverts():
+    strategy.setMetadataURI("ipfs://test3", {"from": strategist})
+    assert strategy.metadataURI() == "ipfs://test3"
+    with brownie.reverts("!authorized"):
         strategy.setMetadataURI("ipfs://fake", {"from": rando})

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -9,14 +9,14 @@ def test_harvest_tend_authority(gov, keeper, strategist, strategy, rando):
     strategy.tend({"from": keeper})
     strategy.tend({"from": strategist})
     strategy.tend({"from": gov})
-    with brownie.reverts():
+    with brownie.reverts("!authorized"):
         strategy.tend({"from": rando})
 
     # Only keeper, strategist, or gov can call harvest
     strategy.harvest({"from": keeper})
     strategy.harvest({"from": strategist})
     strategy.harvest({"from": gov})
-    with brownie.reverts():
+    with brownie.reverts("!authorized"):
         strategy.harvest({"from": rando})
 
 

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -96,7 +96,7 @@ def test_sweep(gov, vault, strategy, rando, token, other_token):
     assert other_token.balanceOf(strategy) > 0
     assert other_token.balanceOf(gov) == 0
     # Not any random person can do this
-    with brownie.reverts():
+    with brownie.reverts("!authorized"):
         strategy.sweep(other_token, {"from": rando})
 
     before = other_token.balanceOf(strategy)

--- a/tests/functional/strategy/test_misc.py
+++ b/tests/functional/strategy/test_misc.py
@@ -67,9 +67,9 @@ def test_harvest_tend_trigger(chain, gov, vault, token, TestStrategy):
     totalDebt = vault.strategies(strategy).dict()["totalDebt"]
     assert strategy.estimatedTotalAssets() + strategy.debtThreshold() < totalDebt
     assert strategy.harvestTrigger(MAX_UINT256)
-    
+
     chain.undo()
-    
+
     # Check that trigger works in emergency exit mode
     strategy.setEmergencyExit({"from": gov})
     assert strategy.harvestTrigger(MAX_UINT256)

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -124,11 +124,11 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain, withSurplus)
     assert token.balanceOf(vault) == initial_investment + strategyReturn - stolen_funds
 
 
-def test_set_emergency_exit_permissions(strategy, gov, strategist, keeper, rando):
+def test_set_emergency_exit_authority(strategy, gov, strategist, keeper, rando):
     # Can only setEmergencyExit as governance or strategist
     strategy.setEmergencyExit({"from": gov})
     strategy.setEmergencyExit({"from": strategist})
-    with brownie.reverts():
+    with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": keeper})
-    with brownie.reverts():
+    with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": rando})

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -1,4 +1,5 @@
 import pytest
+import brownie
 
 DAY = 86400  # seconds
 
@@ -121,3 +122,13 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain, withSurplus)
     strategyReturn = vault.strategies(strategy).dict()["totalGain"]
     assert strategyReturn > 0
     assert token.balanceOf(vault) == initial_investment + strategyReturn - stolen_funds
+
+
+def test_set_emergency_exit_permissions(strategy, gov, strategist, keeper, rando):
+    # Can only setEmergencyExit as governance or strategist
+    strategy.setEmergencyExit({"from": gov})
+    strategy.setEmergencyExit({"from": strategist})
+    with brownie.reverts():
+        strategy.setEmergencyExit({"from": keeper})
+    with brownie.reverts():
+        strategy.setEmergencyExit({"from": rando})

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -126,11 +126,10 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain, withSurplus)
 
 def test_set_emergency_exit_authority(strategy, gov, strategist, keeper, rando):
     # Can only setEmergencyExit as governance or strategist
-    strategy.setEmergencyExit({"from": gov})
-    brownie.chain.undo()
-    strategy.setEmergencyExit({"from": strategist})
-    brownie.chain.undo()
     with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": keeper})
     with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": rando})
+    strategy.setEmergencyExit({"from": gov})
+    brownie.chain.undo()
+    strategy.setEmergencyExit({"from": strategist})

--- a/tests/functional/strategy/test_shutdown.py
+++ b/tests/functional/strategy/test_shutdown.py
@@ -127,7 +127,9 @@ def test_emergency_exit(token, gov, vault, strategy, keeper, chain, withSurplus)
 def test_set_emergency_exit_authority(strategy, gov, strategist, keeper, rando):
     # Can only setEmergencyExit as governance or strategist
     strategy.setEmergencyExit({"from": gov})
+    brownie.chain.undo()
     strategy.setEmergencyExit({"from": strategist})
+    brownie.chain.undo()
     with brownie.reverts("!authorized"):
         strategy.setEmergencyExit({"from": keeper})
     with brownie.reverts("!authorized"):


### PR DESCRIPTION
This includes a handful of coverage improvements for BaseStrategy. After the change, the only issues shown by `brownie gui` are in the `only*` modifiers.

The overall coverage goes from 80.6% -> 86%, but I think that includes all of TestStrategy and its dependencies, which dilutes the coverage numbers a bit. Just focusing on BaseStrategy, I think coverage will be in pretty good shape with this PR.

Current coverage:

```
  contract: TestStrategy - 80.6%
    Address.functionCall - 100.0%
    Address.isContract - 100.0%
    BaseStrategy.apiVersion - 100.0%
    BaseStrategy.governance - 100.0%
    BaseStrategy.isActive - 100.0%
    BaseStrategy.migrate - 100.0%
    BaseStrategy.setDebtThreshold - 100.0%
    BaseStrategy.setMaxReportDelay - 100.0%
    BaseStrategy.setMetadataURI - 100.0%
    BaseStrategy.setMinReportDelay - 100.0%
    BaseStrategy.setProfitFactor - 100.0%
    BaseStrategy.setStrategist - 100.0%
    BaseStrategy.tend - 100.0%
    BaseStrategy.withdraw - 100.0%
    SafeERC20.safeTransfer - 100.0%
    TestStrategy._takeFunds - 100.0%
    TestStrategy._toggleReentrancyExploit - 100.0%
    TestStrategy.estimatedTotalAssets - 100.0%
    TestStrategy.name - 100.0%
    TestStrategy.prepareReturn - 100.0%
    TestStrategy.protectedTokens - 100.0%
    TestStrategy.liquidatePosition - 93.8%
    BaseStrategy.harvestTrigger - 88.7%
    BaseStrategy.sweep - 87.5%
    BaseStrategy.setKeeper - 75.0%
    BaseStrategy.setRewards - 75.0%
    SafeERC20._callOptionalReturn - 75.0%
    BaseStrategy.harvest - 55.7%
    Address._functionCallWithValue - 50.0%
    BaseStrategy.setEmergencyExit - 50.0%
    SafeERC20.safeApprove - 0.0%
```

Coverage with this PR:

```
  contract: TestStrategy - 86.0%
    Address.functionCall - 100.0%
    Address.isContract - 100.0%
    BaseStrategy.apiVersion - 100.0%
    BaseStrategy.governance - 100.0%
    BaseStrategy.harvestTrigger - 100.0%
    BaseStrategy.isActive - 100.0%
    BaseStrategy.migrate - 100.0%
    BaseStrategy.setDebtThreshold - 100.0%
    BaseStrategy.setKeeper - 100.0%
    BaseStrategy.setMaxReportDelay - 100.0%
    BaseStrategy.setMetadataURI - 100.0%
    BaseStrategy.setMinReportDelay - 100.0%
    BaseStrategy.setProfitFactor - 100.0%
    BaseStrategy.setRewards - 100.0%
    BaseStrategy.setStrategist - 100.0%
    BaseStrategy.tend - 100.0%
    BaseStrategy.withdraw - 100.0%
    SafeERC20.safeTransfer - 100.0%
    TestStrategy._takeFunds - 100.0%
    TestStrategy._toggleReentrancyExploit - 100.0%
    TestStrategy.estimatedTotalAssets - 100.0%
    TestStrategy.name - 100.0%
    TestStrategy.prepareReturn - 100.0%
    TestStrategy.protectedTokens - 100.0%
    TestStrategy.liquidatePosition - 93.8%
    BaseStrategy.sweep - 87.5%
    BaseStrategy.harvest - 80.0%
    SafeERC20._callOptionalReturn - 75.0%
    Address._functionCallWithValue - 50.0%
    BaseStrategy.setEmergencyExit - 50.0%
    SafeERC20.safeApprove - 0.0%
```

This is partial work towards #156 