### PR TITLE
fix(time): fixes SECS_PER_YEAR to gregorian constant

### DIFF
--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -229,7 +229,11 @@ managementFee: public(uint256)
 # Governance Fee for performance of Vault (given to `rewards`)
 performanceFee: public(uint256)
 MAX_BPS: constant(uint256) = 10_000  # 100%, or 10k basis points
-SECS_PER_YEAR: constant(uint256) = 31_557_600  # 365.25 days
+# NOTE: A four-century period will be missing 3 of its 100 Julian leap years, leaving 97. 
+#       So the average year has 365 + 97/400 = 365.2425 days 
+#       ERROR(Julian): -0.0078
+#       ERROR(Gregorian): -0.0003
+SECS_PER_YEAR: constant(uint256) = 31_556_926  # 365.24 days
 # `nonces` track `permit` approvals with signature.
 nonces: public(HashMap[address, uint256])
 DOMAIN_SEPARATOR: public(bytes32)

--- a/contracts/Vault.vy
+++ b/contracts/Vault.vy
@@ -233,7 +233,7 @@ MAX_BPS: constant(uint256) = 10_000  # 100%, or 10k basis points
 #       So the average year has 365 + 97/400 = 365.2425 days 
 #       ERROR(Julian): -0.0078
 #       ERROR(Gregorian): -0.0003
-SECS_PER_YEAR: constant(uint256) = 31_556_926  # 365.24 days
+SECS_PER_YEAR: constant(uint256) = 31_556_952  # 365.2425 days
 # `nonces` track `permit` approvals with signature.
 nonces: public(HashMap[address, uint256])
 DOMAIN_SEPARATOR: public(bytes32)


### PR DESCRIPTION
## Utilize gregorian average for days 

According to the Gregorian Calendar, leap years usually occur every 4th year but are skipped every 100 years unless the year is divisible by 400. 400, 800, 1200, 1600, and 2000 ARE leap years but 100, 200,300, 500 . are not.  Thus 2000 is a leap year but 1900 and 2100 are not.  A four-century period will be missing 3 of its 100 Julian leap years, leaving 97.  So the **average year** has 365 + 97/400 = **365.2425** days.
### Unix Timestamp

1 year (365 days) | 31536000 seconds
-- | --
1 year (avg. 365.24 days) | 31556926 seconds
leap year (366 days) | 31622400 seconds




### Table Reference 

| ****                                               | **AverageYear(Days)** | **ErrorPerYear(Days)** | **ErrorRatio** | **CylcePeriod** | **1-DayShift** | **100-yearError(Days)** |
|----------------------------------------------------|-----------------------|------------------------|----------------|-----------------|----------------|-------------------------|
| 365                                                | 365                   | 0.2422                 | 6.63 xx10-4    | 1,508           | 4.129          | 24.22                   |
| Julian                                             | 365.25                | -0.0078                | 2.14 xx10-5    | 46,826          | 128.2          | 0.78                    |
| Gregorian                                          | 365.2425              | -0.0003                | 8.2 xx10-7     | 1,200,000       | 3,333.30       | 0.03                    |
| 4000                                               | 365.24225             | -0.00005               | 1.4 xx10-7     | 7,300,000       | 20,000         | 0.005                   |
| 2//900                                             | 365.2422              | -0.000022              | 6.1 xx10-8     | 16,000,000      | 45,000         | 0.002                   |
| Jalaali                                            | 365.242424            | -0.000224              | 6.1 xx10-7     | 1,600,000       | 4,460          | 0.02                    |
| 31//128                                            | 365.24218750 | 0 .0000125             | 3.4 xx10-8     | 29,000,000      | 80,000         | 0.001                   |

source: https://pumas.nasa.gov/files/04_21_97_1.pdf

